### PR TITLE
[UIMA-5808] Destroy auto-created resource managers if feasible

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/component/initialize/ConfigurationParameterInitializer.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/component/initialize/ConfigurationParameterInitializer.java
@@ -37,7 +37,9 @@ import org.apache.uima.resource.ConfigurationManager;
 import org.apache.uima.resource.CustomResourceSpecifier;
 import org.apache.uima.resource.DataResource;
 import org.apache.uima.resource.Parameter;
+import org.apache.uima.resource.Resource;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.ResourceSpecifier;
 import org.apache.uima.resource.metadata.ConfigurationParameterSettings;
 import org.apache.uima.resource.metadata.NameValuePair;
@@ -193,13 +195,23 @@ public final class ConfigurationParameterInitializer {
    */
   public static void initialize(final Object component, final Map<String, Object> map)
           throws ResourceInitializationException {
-    UimaContextAdmin context = UIMAFramework.newUimaContext(UIMAFramework.getLogger(),
-            ResourceManagerFactory.newResourceManager(), UIMAFramework.newConfigurationManager());
+    // If there is already a UimaContext then re-use that, otherwise create a new one.
+    UimaContextAdmin context;
+    if (component instanceof Resource) {
+      context = ((Resource) component).getUimaContextAdmin();
+    } else {
+      ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
+      context = UIMAFramework.newUimaContext(UIMAFramework.getLogger(), resMgr,
+              UIMAFramework.newConfigurationManager());
+    }
+
     ConfigurationManager cfgMgr = context.getConfigurationManager();
     cfgMgr.setSession(context.getSession());
+    
     for (Entry<String, Object> e : map.entrySet()) {
       cfgMgr.setConfigParameterValue(context.getQualifiedContextName() + e.getKey(), e.getValue());
     }
+
     initialize(component, context);
   }
 

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/CollectionReaderFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/CollectionReaderFactory.java
@@ -43,6 +43,7 @@ import org.apache.uima.fit.internal.ResourceManagerFactory;
 import org.apache.uima.resource.ExternalResourceDescription;
 import org.apache.uima.resource.ResourceCreationSpecifier;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.ResourceSpecifier;
 import org.apache.uima.resource.metadata.Capability;
 import org.apache.uima.resource.metadata.ConfigurationParameter;
@@ -162,12 +163,12 @@ public final class CollectionReaderFactory {
    */
   public static CollectionReader createReader(String descriptorName,
           Object... configurationData) throws UIMAException, IOException {
+    ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
     Import imp = UIMAFramework.getResourceSpecifierFactory().createImport();
     imp.setName(descriptorName);
-    URL url = imp.findAbsoluteUrl(ResourceManagerFactory.newResourceManager());
+    URL url = imp.findAbsoluteUrl(resMgr);
     ResourceSpecifier specifier = createResourceCreationSpecifier(url, configurationData);
-    return UIMAFramework.produceCollectionReader(specifier,
-            ResourceManagerFactory.newResourceManager(), null);
+    return UIMAFramework.produceCollectionReader(specifier, resMgr, null);
   }
 
   /**

--- a/uimafit-core/src/main/java/org/apache/uima/fit/pipeline/JCasIterable.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/pipeline/JCasIterable.java
@@ -63,9 +63,11 @@ public class JCasIterable implements Iterable<JCas> {
     engines = aEngines;
   }
 
+  @Override
   public JCasIterator iterator() {
+    ResourceManager resMgr = null;
     try {
-      ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
+      resMgr = ResourceManagerFactory.newResourceManager();
       
       // Create the components
       CollectionReader readerInst = UIMAFramework.produceCollectionReader(reader, resMgr, null);
@@ -76,12 +78,17 @@ public class JCasIterable implements Iterable<JCas> {
       // Instantiate AAE
       AnalysisEngine aaeInst = UIMAFramework.produceAnalysisEngine(aaeDesc, resMgr, null);
       
-      JCasIterator i = new JCasIterator(readerInst, aaeInst);
+      JCasIterator i = new JCasIterator(resMgr, readerInst, aaeInst);
       i.setSelfComplete(true);
       i.setSelfDestroy(true);
       return i;
     } catch (UIMAException e) {
       throw new IllegalStateException(e);
+    }
+    finally {
+      if (resMgr != null) {
+        resMgr.destroy();
+      }
     }
   }
 }

--- a/uimafit-core/src/main/java/org/apache/uima/fit/util/LifeCycleUtil.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/util/LifeCycleUtil.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.collection.base_cpm.BaseCollectionReader;
 import org.apache.uima.resource.Resource;
+import org.apache.uima.resource.ResourceManager;
 
 /**
  * Helper methods to handle the life cycle of UIMA components.
@@ -47,6 +48,18 @@ public final class LifeCycleUtil {
           throws AnalysisEngineProcessException {
     for (AnalysisEngine e : engines) {
       e.collectionProcessComplete();
+    }
+  }
+
+  /**
+   * Destroy a set of {@link ResourceManager resource manager}.
+   * 
+   * @param aResMgr
+   *          the resource manager to destroy
+   */
+  public static void destroy(final ResourceManager aResMgr) {
+    if (aResMgr != null) {
+      aResMgr.destroy();
     }
   }
 


### PR DESCRIPTION
- Destroy resource manager in JCasIterator
- Use resource manager from reader in SimplePipeline to create CAS instead of creating a new one
- Re-use resource manager from component in ConfigurationParameterInitializer if possible