### PR TITLE
[UIMA-3563] createTypePriorities accepts non-JCas classes

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.commons.logging.LogFactory;
 import org.apache.uima.fit.internal.MetaDataType;
 import org.apache.uima.fit.internal.ResourceManagerFactory;
+import org.apache.uima.jcas.cas.TOP;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.metadata.TypePriorities;
@@ -57,9 +58,14 @@ public final class TypePrioritiesFactory {
    *          a sequence of ordered type classes
    * @return type priorities created from the ordered JCas classes
    */
-  public static TypePriorities createTypePriorities(Class<?>... prioritizedTypes) {
+  @SafeVarargs
+  public static TypePriorities createTypePriorities(Class<? extends TOP>... prioritizedTypes) {
     String[] typeNames = new String[prioritizedTypes.length];
     for (int i = 0; i < prioritizedTypes.length; i++) {
+      if (!TOP.class.isAssignableFrom(prioritizedTypes[i])) {
+        throw new IllegalArgumentException("[" + prioritizedTypes[i] + "] is not a JCas type");
+      }
+      
       String typeName = prioritizedTypes[i].getName();
       if (typeName.startsWith(UIMA_BUILTIN_JCAS_PREFIX)) {
         typeName = "uima." + typeName.substring(UIMA_BUILTIN_JCAS_PREFIX.length());

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypePrioritiesFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypePrioritiesFactoryTest.java
@@ -21,41 +21,52 @@ package org.apache.uima.fit.factory;
 
 import static org.apache.uima.fit.factory.TypePrioritiesFactory.createTypePriorities;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.type.Sentence;
 import org.apache.uima.fit.type.Token;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.resource.metadata.TypePriorities;
-import org.apache.uima.resource.metadata.TypePriorityList;
 import org.apache.uima.util.CasCreationUtils;
 import org.junit.Test;
 
 /**
  * Tests for the {@link TypePrioritiesFactory}.
- * 
  */
 public class TypePrioritiesFactoryTest {
 
   @Test
-  public void testCreateTypePrioritiesClassOfQArray() throws Exception {
+  public void testCreateTypePrioritiesFromTypeNames() throws Exception {
+    TypePriorities prio = createTypePriorities(CAS.TYPE_NAME_ANNOTATION);
+
+    CasCreationUtils.createCas(createTypeSystemDescription(), prio, null);
+
+    assertThat(prio.getPriorityLists()).hasSize(1);
+    assertThat(prio.getPriorityLists()[0].getTypes()).containsExactly(CAS.TYPE_NAME_ANNOTATION);
+  }
+  
+  @Test
+  public void testCreateTypePrioritiesFromClasses() throws Exception {
     TypePriorities prio = createTypePriorities(Annotation.class);
 
     CasCreationUtils.createCas(createTypeSystemDescription(), prio, null);
 
-    assertEquals(1, prio.getPriorityLists().length);
-    assertEquals(1, prio.getPriorityLists()[0].getTypes().length);
-    assertEquals("uima.tcas.Annotation", prio.getPriorityLists()[0].getTypes()[0]);
+    assertThat(prio.getPriorityLists()).hasSize(1);
+    assertThat(prio.getPriorityLists()[0].getTypes()).containsExactly(CAS.TYPE_NAME_ANNOTATION);
   }
   
-
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateTypePrioritiesFromBadClasses() throws Exception {
+    TypePriorities prio = createTypePriorities((Class) Integer.class);
+  }
+  
   @Test
   public void testAutoDetectTypePriorities() throws Exception {
-    TypePriorities typePriorities = createTypePriorities();
+    TypePriorities prio = createTypePriorities();
 
-    TypePriorityList[] typePrioritiesLists = typePriorities.getPriorityLists();
-    assertEquals(1, typePrioritiesLists.length);
-    assertEquals(Sentence.class.getName(), typePrioritiesLists[0].getTypes()[0]);
-    assertEquals(Token.class.getName(), typePrioritiesLists[0].getTypes()[1]);
+    assertThat(prio.getPriorityLists()).hasSize(1);
+    assertThat(prio.getPriorityLists()[0].getTypes()).containsExactly(Sentence.class.getName(),
+            Token.class.getName());
   }
 }


### PR DESCRIPTION
- Changed createTypePriorities to restrict the accepted classes type to JCas cover types
- Added additional unit tests