### PR TITLE
[UIMA-5823] Add basic benchmarking module

### DIFF
--- a/uimafit-benchmark/pom.xml
+++ b/uimafit-benchmark/pom.xml
@@ -90,7 +90,7 @@
             <id>add-test-source</id>
             <phase>process-resources</phase>
             <goals>
-              <goal>add-test-source</goal>
+              <goal>add-source</goal>
             </goals>
             <configuration>
               <sources>


### PR DESCRIPTION
Just a small fix to the build setup discovered when upgrading to Eclipse Photon.