### PR TITLE
[UIMA-3562] Avoid throwing UIMAException

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/CasFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/CasFactory.java
@@ -27,9 +27,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.internal.ResourceManagerFactory;
+import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.metadata.FsIndexCollection;
 import org.apache.uima.resource.metadata.TypePriorities;
@@ -54,10 +54,10 @@ public final class CasFactory {
    * @param aText
    *          the document text to be set in the new CAS.
    * @return a new CAS
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the CAS could not be initialized
    */
-  public static CAS createText(String aText) throws UIMAException {
+  public static CAS createText(String aText) throws ResourceInitializationException {
     return createText(aText, null);
   }
 
@@ -72,10 +72,11 @@ public final class CasFactory {
    * @param aLanguage 
    *          the document language to be set in the new CAS.
    * @return a new CAS
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the CAS could not be initialized
    */
-  public static CAS createText(String aText, String aLanguage) throws UIMAException {
+  public static CAS createText(String aText, String aLanguage)
+          throws ResourceInitializationException {
     CAS cas = createCas();
     if (aText != null) {
       cas.setDocumentText(aText);
@@ -93,10 +94,10 @@ public final class CasFactory {
    * detected automatically using {@link FsIndexFactory#createFsIndexCollection()}.
    * 
    * @return a new CAS
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the CAS could not be initialized
    */
-  public static CAS createCas() throws UIMAException {
+  public static CAS createCas() throws ResourceInitializationException {
     TypeSystemDescription tsd = createTypeSystemDescription();
     TypePriorities tp = createTypePriorities();
     FsIndexCollection indexes = createFsIndexCollection();
@@ -112,10 +113,11 @@ public final class CasFactory {
    *          names of the type system descriptors on the classpath used to initialize the CAS (in
    *          Java notation, e.g. "my.package.TypeSystem" without the ".xml" extension)
    * @return a new CAS
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the CAS could not be initialized
    */
-  public static CAS createCas(String... typeSystemDescriptorNames) throws UIMAException {
+  public static CAS createCas(String... typeSystemDescriptorNames)
+          throws ResourceInitializationException {
     return CasCreationUtils.createCas(createTypeSystemDescription(typeSystemDescriptorNames), null,
             null);
   }
@@ -127,10 +129,11 @@ public final class CasFactory {
    * @param typeSystemDescriptorPaths
    *          paths to type system descriptor files
    * @return a new CAS
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the CAS could not be initialized
    */
-  public static CAS createCasFromPath(String... typeSystemDescriptorPaths) throws UIMAException {
+  public static CAS createCasFromPath(String... typeSystemDescriptorPaths)
+          throws ResourceInitializationException {
     return createCas(createTypeSystemDescriptionFromPath(typeSystemDescriptorPaths));
   }
 
@@ -141,10 +144,11 @@ public final class CasFactory {
    * @param typeSystemDescription
    *          a type system description to initialize the CAS
    * @return a new CAS
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the CAS could not be initialized
    */
-  public static CAS createCas(TypeSystemDescription typeSystemDescription) throws UIMAException {
+  public static CAS createCas(TypeSystemDescription typeSystemDescription)
+          throws ResourceInitializationException {
     return CasCreationUtils.createCas(typeSystemDescription, null, null);
   }
 
@@ -156,13 +160,13 @@ public final class CasFactory {
    * @param typeSystemDescription
    *          a type system description to initialize the CAS
    * @return a new CAS
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the CAS could not be initialized
    * @throws IOException
    *           if there is a problem reading the file
    */
   public static CAS createCas(String fileName, TypeSystemDescription typeSystemDescription)
-          throws UIMAException, IOException {
+          throws ResourceInitializationException, IOException {
     CAS cas = createCas(typeSystemDescription);
     try (InputStream is = new FileInputStream(fileName)) {
       CasIOUtils.load(is, cas);

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/CollectionReaderFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/CollectionReaderFactory.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.uima.Constants;
-import org.apache.uima.UIMAException;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.collection.CollectionReader;
 import org.apache.uima.collection.CollectionReaderDescription;
@@ -52,6 +51,7 @@ import org.apache.uima.resource.metadata.Import;
 import org.apache.uima.resource.metadata.ResourceMetaData;
 import org.apache.uima.resource.metadata.TypePriorities;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.InvalidXMLException;
 
 /**
  */
@@ -70,13 +70,16 @@ public final class CollectionReaderFactory {
    *          Any additional configuration parameters to be set. These should be supplied as (name,
    *          value) pairs, so there should always be an even number of parameters.
    * @return The CollectionReader created from the XML descriptor and the configuration parameters.
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the descriptor could not be created or if the component could not be instantiated
+   * @throws InvalidXMLException
+   *           if the descriptor could not be created
    * @throws IOException
    *           if the descriptor could not be read
    */
   public static CollectionReader createReaderFromPath(String descriptorPath,
-          Object... configurationData) throws UIMAException, IOException {
+          Object... configurationData)
+          throws ResourceInitializationException, InvalidXMLException, IOException {
     CollectionReaderDescription desc = createReaderDescriptionFromPath(descriptorPath,
             configurationData);
     return UIMAFramework.produceCollectionReader(desc, ResourceManagerFactory.newResourceManager(),
@@ -93,14 +96,17 @@ public final class CollectionReaderFactory {
    *          value) pairs, so there should always be an even number of parameters.
    * @return The CollectionReader created from the XML descriptor and the configuration parameters.
    * @deprecated use {@link #createReaderFromPath(String, Object...)}
-   * @throws UIMAException
+   * @throws ResourceInitializationException
    *           if the descriptor could not be created or if the component could not be instantiated
+   * @throws InvalidXMLException
+   *           if the descriptor could not be created
    * @throws IOException
    *           if the descriptor could not be read
    */
   @Deprecated
   public static CollectionReader createCollectionReaderFromPath(String descriptorPath,
-          Object... configurationData) throws UIMAException, IOException {
+          Object... configurationData)
+          throws ResourceInitializationException, InvalidXMLException, IOException {
     return createReaderFromPath(descriptorPath, configurationData);
   }
 
@@ -113,13 +119,13 @@ public final class CollectionReaderFactory {
    *          Any additional configuration parameters to be set. These should be supplied as (name,
    *          value) pairs, so there should always be an even number of parameters.
    * @return the description created from the XML descriptor and the configuration parameters.
-   * @throws UIMAException
+   * @throws InvalidXMLException
    *           if the descriptor could not be created or if the component could not be instantiated
    * @throws IOException
    *           if the descriptor could not be read
    */
   public static CollectionReaderDescription createReaderDescriptionFromPath(String descriptorPath,
-          Object... configurationData) throws UIMAException, IOException {
+          Object... configurationData) throws InvalidXMLException, IOException {
     ResourceCreationSpecifier specifier = createResourceCreationSpecifier(descriptorPath,
             configurationData);
     return (CollectionReaderDescription) specifier;
@@ -135,14 +141,15 @@ public final class CollectionReaderFactory {
    *          value) pairs, so there should always be an even number of parameters.
    * @return The CollectionReader created from the XML descriptor and the configuration parameters.
    * @deprecated use {@link #createReaderDescriptionFromPath(String, Object...)}
-   * @throws UIMAException
+   * @throws InvalidXMLException
    *           if the descriptor could not be created or if the component could not be instantiated
    * @throws IOException
    *           if the descriptor could not be read
    */
   @Deprecated
   public static CollectionReaderDescription createCollectionReaderDescriptionFromPath(
-          String descriptorPath, Object... configurationData) throws UIMAException, IOException {
+          String descriptorPath, Object... configurationData)
+          throws InvalidXMLException, IOException {
     return createReaderDescriptionFromPath(descriptorPath, configurationData);
   }
 
@@ -156,13 +163,15 @@ public final class CollectionReaderFactory {
    *          Any additional configuration parameters to be set. These should be supplied as (name,
    *          value) pairs, so there should always be an even number of parameters.
    * @return The AnalysisEngine created from the XML descriptor and the configuration parameters.
-   * @throws UIMAException
+   * @throws ResourceInitializationException 
    *           if the descriptor could not be created or if the component could not be instantiated
+   * @throws InvalidXMLException 
+   *           if the descriptor could not be created
    * @throws IOException
    *           if the descriptor could not be read
    */
-  public static CollectionReader createReader(String descriptorName,
-          Object... configurationData) throws UIMAException, IOException {
+  public static CollectionReader createReader(String descriptorName, Object... configurationData)
+          throws IOException, ResourceInitializationException, InvalidXMLException {
     ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
     Import imp = UIMAFramework.getResourceSpecifierFactory().createImport();
     imp.setName(descriptorName);
@@ -182,14 +191,17 @@ public final class CollectionReaderFactory {
    *          value) pairs, so there should always be an even number of parameters.
    * @return The AnalysisEngine created from the XML descriptor and the configuration parameters.
    * @deprecated use {@link #createReader(String, Object...)}
-   * @throws UIMAException
+   * @throws ResourceInitializationException 
    *           if the descriptor could not be created or if the component could not be instantiated
+   * @throws InvalidXMLException 
+   *           if the descriptor could not be created
    * @throws IOException
    *           if the descriptor could not be read
    */
   @Deprecated
   public static CollectionReader createCollectionReader(String descriptorName,
-          Object... configurationData) throws UIMAException, IOException {
+          Object... configurationData)
+          throws IOException, ResourceInitializationException, InvalidXMLException {
     return createReader(descriptorName, configurationData);
   }
 

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/JCasFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/JCasFactory.java
@@ -20,8 +20,9 @@ package org.apache.uima.fit.factory;
 
 import java.io.IOException;
 
-import org.apache.uima.UIMAException;
+import org.apache.uima.cas.CASException;
 import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 /**
@@ -41,10 +42,12 @@ public final class JCasFactory {
    * @param aText
    *          the document text to be set in the new JCas.
    * @return a new JCas
-   * @throws UIMAException
+   * @throws ResourceInitializationException
+   *           if the CAS could not be initialized
+   * @throws CASException 
    *           if the JCas could not be initialized
    */
-  public static JCas createText(String aText) throws UIMAException {
+  public static JCas createText(String aText) throws ResourceInitializationException, CASException {
     return CasFactory.createText(aText, null).getJCas();
   }
 
@@ -59,10 +62,13 @@ public final class JCasFactory {
    * @param aLanguage 
    *          the document language to be set in the new JCas.
    * @return a new JCas
-   * @throws UIMAException
+   * @throws ResourceInitializationException
+   *           if the CAS could not be initialized
+   * @throws CASException 
    *           if the JCas could not be initialized
    */
-  public static JCas createText(String aText, String aLanguage) throws UIMAException {
+  public static JCas createText(String aText, String aLanguage)
+          throws ResourceInitializationException, CASException {
     return CasFactory.createText(aText, aLanguage).getJCas();
   }
   
@@ -73,10 +79,12 @@ public final class JCasFactory {
    * detected automatically using {@link FsIndexFactory#createFsIndexCollection()}.
    * 
    * @return a new JCas
-   * @throws UIMAException
+   * @throws ResourceInitializationException
+   *           if the CAS could not be initialized
+   * @throws CASException 
    *           if the JCas could not be initialized
    */
-  public static JCas createJCas() throws UIMAException {
+  public static JCas createJCas() throws ResourceInitializationException, CASException {
     return CasFactory.createCas().getJCas();
   }
 
@@ -88,10 +96,13 @@ public final class JCasFactory {
    *          names of the type system descriptors on the classpath used to initialize the JCas (in
    *          Java notation, e.g. "my.package.TypeSystem" without the ".xml" extension)
    * @return a new JCas
-   * @throws UIMAException
+   * @throws ResourceInitializationException
+   *           if the CAS could not be initialized
+   * @throws CASException 
    *           if the JCas could not be initialized
    */
-  public static JCas createJCas(String... typeSystemDescriptorNames) throws UIMAException {
+  public static JCas createJCas(String... typeSystemDescriptorNames)
+          throws ResourceInitializationException, CASException {
     return CasFactory.createCas(typeSystemDescriptorNames).getJCas();
   }
 
@@ -102,10 +113,13 @@ public final class JCasFactory {
    * @param typeSystemDescriptorPaths
    *          paths to type system descriptor files
    * @return a new JCas
-   * @throws UIMAException
+   * @throws ResourceInitializationException
+   *           if the CAS could not be initialized
+   * @throws CASException 
    *           if the JCas could not be initialized
    */
-  public static JCas createJCasFromPath(String... typeSystemDescriptorPaths) throws UIMAException {
+  public static JCas createJCasFromPath(String... typeSystemDescriptorPaths)
+          throws ResourceInitializationException, CASException {
     return CasFactory.createCasFromPath(typeSystemDescriptorPaths).getJCas();
   }
 
@@ -116,10 +130,13 @@ public final class JCasFactory {
    * @param typeSystemDescription
    *          a type system description to initialize the JCas
    * @return a new JCas
-   * @throws UIMAException
+   * @throws ResourceInitializationException
+   *           if the CAS could not be initialized
+   * @throws CASException 
    *           if the JCas could not be initialized
    */
-  public static JCas createJCas(TypeSystemDescription typeSystemDescription) throws UIMAException {
+  public static JCas createJCas(TypeSystemDescription typeSystemDescription)
+          throws ResourceInitializationException, CASException {
     return CasFactory.createCas(typeSystemDescription).getJCas();
   }
 
@@ -131,13 +148,15 @@ public final class JCasFactory {
    * @param typeSystemDescription
    *          a type system description to initialize the JCas
    * @return a new JCas
-   * @throws UIMAException
+   * @throws ResourceInitializationException
+   *           if the CAS could not be initialized
+   * @throws CASException 
    *           if the JCas could not be initialized
    * @throws IOException
    *           if there is a problem reading the file
    */
   public static JCas createJCas(String fileName, TypeSystemDescription typeSystemDescription)
-          throws UIMAException, IOException {
+          throws ResourceInitializationException, CASException, IOException {
     return CasFactory.createCas(fileName, typeSystemDescription).getJCas();
   }
 }

--- a/uimafit-core/src/main/java/org/apache/uima/fit/pipeline/SimplePipeline.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/pipeline/SimplePipeline.java
@@ -26,12 +26,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.uima.UIMAException;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.collection.CollectionException;
 import org.apache.uima.collection.CollectionReader;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.fit.factory.AnalysisEngineFactory;
@@ -77,13 +77,18 @@ public final class SimplePipeline {
    *          Primitive AnalysisEngineDescriptions that process the CAS, in order. If you have a mix
    *          of primitive and aggregate engines, then please create the AnalysisEngines yourself
    *          and call the other runPipeline method.
-   * @throws UIMAException
-   *           if there is a problem initializing or running the CPE.
    * @throws IOException
    *           if there is an I/O problem in the reader
+   * @throws ResourceInitializationException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws CollectionException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws AnalysisEngineProcessException 
+   *           if there is a problem initializing or running the pipeline.
    */
   public static void runPipeline(final CollectionReader reader,
-          final AnalysisEngineDescription... descs) throws UIMAException, IOException {
+          final AnalysisEngineDescription... descs) throws IOException,
+          ResourceInitializationException, AnalysisEngineProcessException, CollectionException {
     AnalysisEngine aae = null;
     try {
       // Create AAE
@@ -145,14 +150,18 @@ public final class SimplePipeline {
    *          Primitive AnalysisEngineDescriptions that process the CAS, in order. If you have a mix
    *          of primitive and aggregate engines, then please create the AnalysisEngines yourself
    *          and call the other runPipeline method.
-   * @throws UIMAException
-   *           if there is a problem initializing or running the CPE.
    * @throws IOException
    *           if there is an I/O problem in the reader
+   * @throws ResourceInitializationException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws CollectionException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws AnalysisEngineProcessException 
+   *           if there is a problem initializing or running the pipeline.
    */
   public static void runPipeline(final CollectionReaderDescription readerDesc,
-          final AnalysisEngineDescription... descs) throws UIMAException, IOException {
-    
+          final AnalysisEngineDescription... descs) throws IOException,
+          ResourceInitializationException, AnalysisEngineProcessException, CollectionException {
     CollectionReader reader = null;
     AnalysisEngine aae = null;
     ResourceManager resMgr = null;
@@ -211,13 +220,18 @@ public final class SimplePipeline {
    *          a collection reader
    * @param engines
    *          a sequence of analysis engines
-   * @throws UIMAException
-   *           if there is a problem initializing or running the CPE.
    * @throws IOException
    *           if there is an I/O problem in the reader
+   * @throws CollectionException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws ResourceInitializationException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws AnalysisEngineProcessException 
+   *           if there is a problem initializing or running the pipeline.
    */
   public static void runPipeline(final CollectionReader reader, final AnalysisEngine... engines)
-          throws UIMAException, IOException {
+          throws IOException, AnalysisEngineProcessException, ResourceInitializationException,
+          CollectionException {
     runPipeline(reader.getResourceManager(), reader, engines);
   }
   
@@ -242,13 +256,18 @@ public final class SimplePipeline {
    *          a collection reader
    * @param engines
    *          a sequence of analysis engines
-   * @throws UIMAException
-   *           if there is a problem initializing or running the CPE.
    * @throws IOException
    *           if there is an I/O problem in the reader
+   * @throws ResourceInitializationException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws CollectionException 
+   *           if there is a problem initializing or running the pipeline.
+   * @throws AnalysisEngineProcessException 
+   *           if there is a problem initializing or running the pipeline.
    */
   public static void runPipeline(final ResourceManager aResMgr, final CollectionReader reader,
-          final AnalysisEngine... engines) throws UIMAException, IOException {
+          final AnalysisEngine... engines) throws IOException, ResourceInitializationException,
+          AnalysisEngineProcessException, CollectionException {
     final List<ResourceMetaData> metaData = new ArrayList<ResourceMetaData>();
     metaData.add(reader.getMetaData());
     for (AnalysisEngine engine : engines) {

--- a/uimafit-core/src/main/java/org/apache/uima/fit/testing/factory/TokenBuilder.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/testing/factory/TokenBuilder.java
@@ -21,7 +21,6 @@ package org.apache.uima.fit.testing.factory;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.uima.UIMAException;
 import org.apache.uima.cas.Feature;
 import org.apache.uima.fit.factory.AnnotationFactory;
 import org.apache.uima.jcas.JCas;

--- a/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpePipeline.java
+++ b/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpePipeline.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.uima.UIMAException;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.cas.CAS;
@@ -33,6 +32,8 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.collection.EntityProcessStatus;
 import org.apache.uima.collection.StatusCallbackListener;
 import org.apache.uima.collection.metadata.CpeDescriptorException;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.util.InvalidXMLException;
 import org.xml.sax.SAXException;
 
 /**
@@ -59,12 +60,17 @@ public final class CpePipeline {
    *           referenced from the CPE descriptor
    * @throws CpeDescriptorException
    *           if there was a problem configuring the CPE descriptor
-   * @throws UIMAException
+   * @throws ResourceInitializationException 
    *           if there was a problem initializing or running the CPE.
+   * @throws InvalidXMLException 
+   *           if there was a problem initializing or running the CPE.
+   * @throws AnalysisEngineProcessException 
+   *           if there was a problem running the CPE.
    */
   public static void runPipeline(final CollectionReaderDescription readerDesc,
-          final AnalysisEngineDescription... descs) throws UIMAException, SAXException,
-          CpeDescriptorException, IOException {
+          final AnalysisEngineDescription... descs)
+          throws SAXException, CpeDescriptorException, IOException, ResourceInitializationException,
+          InvalidXMLException, AnalysisEngineProcessException {
     // Create AAE
     final AnalysisEngineDescription aaeDesc = createEngineDescription(descs);
 
@@ -98,6 +104,7 @@ public final class CpePipeline {
 
     private boolean isProcessing = true;
 
+    @Override
     public void entityProcessComplete(CAS arg0, EntityProcessStatus arg1) {
       if (arg1.isException()) {
         for (Exception e : arg1.getExceptions()) {
@@ -106,6 +113,7 @@ public final class CpePipeline {
       }
     }
 
+    @Override
     public void aborted() {
       synchronized (this) {
         if (isProcessing) {
@@ -115,10 +123,12 @@ public final class CpePipeline {
       }
     }
 
+    @Override
     public void batchProcessComplete() {
       // Do nothing
     }
 
+    @Override
     public void collectionProcessComplete() {
       synchronized (this) {
         if (isProcessing) {
@@ -128,14 +138,17 @@ public final class CpePipeline {
       }
     }
 
+    @Override
     public void initializationComplete() {
       // Do nothing
     }
 
+    @Override
     public void paused() {
       // Do nothing
     }
 
+    @Override
     public void resumed() {
       // Do nothing
     }


### PR DESCRIPTION
uimaFIT throws a UIMAException in several places, apparently to avoid separate throws clauses for AnalysisEngineException, ResourceInitializationException and the likes. This is not good, because the different kinds of problems that can occur are somewhat hidden from a person using methods throwing UIMAException. It would be better to declare each exception separately.

https://issues.apache.org/jira/browse/UIMA-3562