### PR TITLE
[UIMA-5853] Java version for integration tests should match main target version

### DIFF
--- a/uimafit-maven-plugin/src/it/default/pom.xml
+++ b/uimafit-maven-plugin/src/it/default/pom.xml
@@ -29,6 +29,8 @@
 	<name>Test for default configuration</name>
 
 	<properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 


### PR DESCRIPTION
- Set the target level for integration tests to 1.7

Jira: https://issues.apache.org/jira/browse/UIMA-5853