### PR TITLE
No Jira - Remove redundant declaration of Java target and source version

### DIFF
--- a/uimafit-benchmark/pom.xml
+++ b/uimafit-benchmark/pom.xml
@@ -32,8 +32,6 @@
   </parent>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
In the v2 branch, this is necessary because the benchmarking module requires Java 8, but in the v3 branch, Java 8 is the standard anyway.

No Jira - this is a minor change.
