### PR TITLE
[UIMA-6010] Upgrade dependencies

### DIFF
--- a/uimafit-benchmark/pom.xml
+++ b/uimafit-benchmark/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -40,10 +40,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
     </dependency>

--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -32,8 +32,8 @@
   </parent>
   <dependencies>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>spring-beans</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
@@ -63,7 +67,6 @@
     <dependency> <!-- https://issues.apache.org/jira/browse/UIMA-5173  -->
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
-      <version>1.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/ConfigurationParameterFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/ConfigurationParameterFactory.java
@@ -26,8 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.IllegalClassException;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.uima.UIMA_IllegalArgumentException;
 import org.apache.uima.fit.factory.ExternalResourceFactory.ResourceValueType;
 import org.apache.uima.fit.internal.ReflectionUtil;
@@ -558,7 +557,7 @@ public final class ConfigurationParameterFactory {
         settings.put(p.getName(), p.getValue());
       }
     } else {
-      throw new IllegalClassException("Unsupported resource specifier class [" + spec.getClass()
+      throw new IllegalArgumentException("Unsupported resource specifier class [" + spec.getClass()
               + "]");
     }
     return settings;
@@ -574,13 +573,13 @@ public final class ConfigurationParameterFactory {
    *          the parameter name.
    * @param value
    *          the parameter value.
-   * @throws IllegalClassException
+   * @throws IllegalArgumentException
    *           if the value is not of a supported type for the given specifier.
    */
   public static void setParameter(ResourceSpecifier aSpec, String name, Object value) {
     if (aSpec instanceof CustomResourceSpecifier) {
       if (!(value instanceof String || value == null)) {
-        throw new IllegalClassException(String.class, value);
+        throw new IllegalArgumentException("Value must be a string");
       }
       CustomResourceSpecifier spec = (CustomResourceSpecifier) aSpec;
 
@@ -625,7 +624,7 @@ public final class ConfigurationParameterFactory {
       md.getConfigurationParameterSettings().setParameterValue(name,
               convertParameterValue(param, value));
     } else {
-      throw new IllegalClassException("Unsupported resource specifier class [" + aSpec.getClass()
+      throw new IllegalArgumentException("Unsupported resource specifier class [" + aSpec.getClass()
               + "]");
     }
   }

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.collection.CollectionReaderDescription;

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/FsIndexFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/FsIndexFactory.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
 import org.apache.uima.fit.descriptor.FsIndex;
 import org.apache.uima.fit.descriptor.FsIndexKey;
 import org.apache.uima.fit.internal.MetaDataType;
@@ -42,10 +41,14 @@ import org.apache.uima.resource.metadata.impl.FsIndexKeyDescription_impl;
 import org.apache.uima.resource.metadata.impl.Import_impl;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  */
 public final class FsIndexFactory {
+  private static Logger LOG = LoggerFactory.getLogger(FsIndexFactory.class); 
+  
   /**
    * Comparator that orders FeatureStructures according to the standard order of their key features.
    * For integer and float values, this is the standard linear order, and for strings it is
@@ -254,12 +257,11 @@ public final class FsIndexFactory {
         FsIndexCollection fsIdxCol = getXMLParser().parseFsIndexCollection(xmlInput);
         fsIdxCol.resolveImports();
         fsIndexList.addAll(asList(fsIdxCol.getFsIndexes()));
-        LogFactory.getLog(FsIndexFactory.class).debug("Detected index at [" + location + "]");
+        LOG.debug("Detected index at [{}]", location);
       } catch (IOException e) {
         throw new ResourceInitializationException(e);
       } catch (InvalidXMLException e) {
-        LogFactory.getLog(FsIndexFactory.class).warn(
-                "[" + location + "] is not a index descriptor file. Ignoring.", e);
+        LOG.warn("[{}] is not a index descriptor file. Ignoring.", location, e);
       }
     }
 

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
 import org.apache.uima.fit.internal.MetaDataType;
 import org.apache.uima.fit.internal.ResourceManagerFactory;
 import org.apache.uima.jcas.cas.TOP;
@@ -38,11 +37,12 @@ import org.apache.uima.resource.metadata.impl.TypePriorities_impl;
 import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
-
-/**
- */
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class TypePrioritiesFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(TypePrioritiesFactory.class);
+    
   private static final Object SCAN_LOCK = new Object();
 
   private static String[] typePriorityDescriptorLocations;
@@ -110,13 +110,11 @@ public final class TypePrioritiesFactory {
         TypePriorities typePriorities = getXMLParser().parseTypePriorities(xmlInput);
         typePriorities.resolveImports();
         typePrioritiesList.add(typePriorities);
-        LogFactory.getLog(TypePrioritiesFactory.class).debug(
-                "Detected type priorities at [" + location + "]");
+        LOG.debug("Detected type priorities at [{}]", location);
       } catch (IOException e) {
         throw new ResourceInitializationException(e);
       } catch (InvalidXMLException e) {
-        LogFactory.getLog(TypePrioritiesFactory.class).warn(
-                "[" + location + "] is not a type priorities descriptor file. Ignoring.", e);
+        LOG.warn("[{}] is not a type priorities descriptor file. Ignoring.", location, e);
       }
     }
 

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.LogFactory;
 import org.apache.uima.fit.internal.MetaDataType;
 import org.apache.uima.fit.internal.ResourceManagerFactory;
 import org.apache.uima.resource.ResourceInitializationException;
@@ -37,10 +36,12 @@ import org.apache.uima.resource.metadata.impl.Import_impl;
 import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- */
 public final class TypeSystemDescriptionFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(TypeSystemDescriptionFactory.class);
+  
   private static final Object SCAN_LOCK = new Object();
 
   private static String[] typeDescriptorLocations;
@@ -105,13 +106,11 @@ public final class TypeSystemDescriptionFactory {
       try {
         XMLInputSource xmlInputType1 = new XMLInputSource(location);
         tsdList.add(getXMLParser().parseTypeSystemDescription(xmlInputType1));
-        LogFactory.getLog(TypeSystemDescription.class).debug(
-                "Detected type system at [" + location + "]");
+        LOG.debug("Detected type system at [{}]", location);
       } catch (IOException e) {
         throw new ResourceInitializationException(e);
       } catch (InvalidXMLException e) {
-        LogFactory.getLog(TypeSystemDescription.class).warn(
-                "[" + location + "] is not a type file. Ignoring.", e);
+        LOG.warn("[{}] is not a type file. Ignoring.", location, e);
       }
     }
 

--- a/uimafit-core/src/main/java/org/apache/uima/fit/internal/MetaDataUtil.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/internal/MetaDataUtil.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;

--- a/uimafit-core/src/test/java/org/apache/uima/fit/util/FSCollectionFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/util/FSCollectionFactoryTest.java
@@ -22,7 +22,7 @@
 package org.apache.uima.fit.util;
 
 import static java.util.Arrays.asList;
-import static org.apache.commons.lang.ArrayUtils.toObject;
+import static org.apache.commons.lang3.ArrayUtils.toObject;
 import static org.apache.uima.fit.util.FSCollectionFactory.create;
 import static org.apache.uima.fit.util.FSCollectionFactory.*;
 import static org.apache.uima.fit.util.FSCollectionFactory.createBooleanArrayFS;

--- a/uimafit-core/src/test/java/org/apache/uima/fit/util/FSUtilTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/util/FSUtilTest.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.cas.ArrayFS;
 import org.apache.uima.cas.CAS;

--- a/uimafit-maven-plugin/pom.xml
+++ b/uimafit-maven-plugin/pom.xml
@@ -46,8 +46,8 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/EnhanceMojo.java
+++ b/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/EnhanceMojo.java
@@ -47,8 +47,8 @@ import javassist.bytecode.annotation.StringMemberValue;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -174,6 +174,7 @@ public class EnhanceMojo extends AbstractMojo {
    */
   private static final String MARK_NO_MISSING_META_DATA = "No missing meta data was found.";
 
+  @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     // Get the compiled classes from this project
     String[] files = FileUtils.getFilesFromExtension(project.getBuild().getOutputDirectory(),

--- a/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/GenerateDescriptorsMojo.java
+++ b/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/GenerateDescriptorsMojo.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Modifier;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;

--- a/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/util/Util.java
+++ b/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/util/Util.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -34,7 +34,7 @@
   <url>${uimaWebsiteUrl}</url>
   <inceptionYear>2012</inceptionYear>
   <properties>
-    <spring.version>3.2.16.RELEASE</spring.version>
+    <spring.version>4.3.22.RELEASE</spring.version>
     <uima.version>3.0.1</uima.version>
     <slf4j.version>1.7.26</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -89,6 +89,11 @@
         <version>4.12</version>
       </dependency>
       <dependency>
+        <groupId>xmlunit</groupId>
+        <artifactId>xmlunit</artifactId>
+        <version>1.6</version>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.12.2</version>
@@ -102,6 +107,11 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -122,11 +132,6 @@
         <groupId>org.apache.uima</groupId>
         <artifactId>uimaj-tools</artifactId>
         <version>${uima.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jdom</groupId>
-        <artifactId>jdom</artifactId>
-        <version>1.1.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -226,7 +231,7 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.11</version>
+          <version>0.13</version>
           <executions>
             <execution>
               <id>default-cli</id>
@@ -256,7 +261,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.8.0</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>
@@ -266,7 +271,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>3.1.0</version>
           <executions>
             <execution>
               <id>attach-javadocs</id>
@@ -325,7 +330,7 @@
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>findbugs-maven-plugin</artifactId>
-              <version>3.0.3</version>
+              <version>3.0.5</version>
               <executions>
                 <execution>
                   <phase>package</phase>
@@ -377,7 +382,7 @@
           <plugin>
             <groupId>com.github.siom79.japicmp</groupId>
             <artifactId>japicmp-maven-plugin</artifactId>
-            <version>0.9.3</version>
+            <version>0.13.1</version>
             <configuration>
               <oldVersion>
                 <dependency>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.10.0</version>
+        <version>3.12.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -101,13 +101,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.2</version>
-        <!-- 2.2 is the last Java 5 compatible version -->
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging-api</artifactId>
-        <version>1.1</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -94,9 +94,9 @@
         <version>3.10.0</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.8.1</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6010

- Switch from commons-lang to commons-lang3
- Throw IllegalArgumentException in some places instead of the IllegalClassException from commons-lang which no longer exists in commons-lang3
- Remove dependencies on Apache Commons Logging and rely fully on SLF4J
- Upgrade to latest commons-io
- Upgrade to latest assertj-core
- Upgrade xmlunit from 1.5 to 1.6 (test only)
- Upgrade Spring from 3.2.16 to 4.3.22 (latest 4.x release)
- Upgrade rat plugin from 0.11 to 0.13
- Upgrade compiler plugin from 3.5.1 to 3.8.0
- Upgrade JavaDoc plugin from 2.10.3 to 3.1.0
- Upgrade Findbugs plugin from 3.0.3 to 3.0.5
- Upgrade japicmp plugin from 0.9.3 to 0.13.1