### PR TITLE
[UIMA-6022] Upgrade to UIMA 3.0.2

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 
-      Apache uimaFIT (TM) v2.3.0
+      Apache uimaFIT (TM) v3.0.0
       --------------------------
 
 
@@ -37,21 +37,20 @@ following list highlights some of the features uimaFIT provides:
      SimplePipeline.runPipeline(reader, ae1, ..., aeN, consumer1, ... consumerN)
 
 
-What's New in 2.3.0
+What's New in 3.0.0
 -------------------
 
-uimaFIT 2.3.0 is a minor feature and bugfix release to uimaFIT 2.2.0. It should should serve as a
-drop-in replacement for previous uimaFIT 2.x versions. Mind that uimaFIT 2.3.0 now requires UIMA
-2.9.0.
+uimaFIT 3.0.0 is a major release because it upgrades uimaFIT to UIMA v3. Upgrading to the new version 
+may require minor adjustments to the code depending on uimaFIT.
 
 A full list of issues addressed in this release can be found on the Apache issue tracker:
 
-  https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310570&version=12332459
+  https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310570&version=12332458
 
 Supported Platforms
 -------------------
 
-uimaFIT requires Java 1.7 or higher, UIMA 2.9.0 or higher, and the Spring Framework 3.2.16 or higher.
+uimaFIT requires Java 1.8 or higher, UIMA 3.0.2 or higher, and the Spring Framework 4.3.22 or higher.
 
 
 Availability
@@ -68,7 +67,7 @@ add uimaFIT as a dependency to your pom.xml file with the following:
   <dependency>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-core</artifactId>
-    <version>2.3.0</version>
+    <version>3.0.0</version>
   </dependency>
 
 

--- a/uimafit-docbook/src/docbook/tools.uimafit.migration.xml
+++ b/uimafit-docbook/src/docbook/tools.uimafit.migration.xml
@@ -35,7 +35,7 @@
     </formalpara>
     <formalpara>
       <title>Version requirements</title>
-      <para>Depends on UIMA 3.0.1, Spring Framework 4.3.22 and Java 8.</para>
+      <para>Depends on UIMA 3.0.2, Spring Framework 4.3.22 and Java 8.</para>
     </formalpara>
   </section>
   <section>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -35,7 +35,7 @@
   <inceptionYear>2012</inceptionYear>
   <properties>
     <spring.version>4.3.22.RELEASE</spring.version>
-    <uima.version>3.0.1</uima.version>
+    <uima.version>3.0.2</uima.version>
     <slf4j.version>1.7.26</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6022

- Updated dependency on core UIMA framework
- Updated UIMA framework version in migration guide
- Picked README file from 3.0.0 release branch and updated UIMA version there as well
