### PR TITLE
[UIMA-6186] Factory methods for resource instances

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
@@ -1273,7 +1273,7 @@ public final class ExternalResourceFactory {
    * @throws ResourceInitializationException
    *           if there was a problem instantiating the resource.
    */
-  public static <R> R createResource(Class<? extends Resource> resourceClass,
+  public static <R extends Resource> R createResource(Class<R> resourceClass,
           Object... params) throws ResourceInitializationException {
     return createResource(resourceClass, null, params);
   }
@@ -1295,7 +1295,7 @@ public final class ExternalResourceFactory {
    *           if there was a problem instantiating the resource.
    */
   @SuppressWarnings("unchecked")
-  public static <R> R createResource(Class<? extends Resource> resourceClass,
+  public static <R extends Resource> R createResource(Class<R> resourceClass,
           ResourceManager resMgr, Object... params) throws ResourceInitializationException {
     ExternalResourceDescription res = createExternalResourceDescription(resourceClass, params);
     return (R) produceResource(resourceClass, res.getResourceSpecifier(), resMgr, emptyMap());

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
@@ -1273,9 +1273,9 @@ public final class ExternalResourceFactory {
    * @throws ResourceInitializationException
    *           if there was a problem instantiating the resource.
    */
-  public static <R> R createExternalResource(Class<? extends Resource> resourceClass,
+  public static <R> R createResource(Class<? extends Resource> resourceClass,
           Object... params) throws ResourceInitializationException {
-    return createExternalResource(resourceClass, null, params);
+    return createResource(resourceClass, null, params);
   }
 
   /**
@@ -1295,7 +1295,7 @@ public final class ExternalResourceFactory {
    *           if there was a problem instantiating the resource.
    */
   @SuppressWarnings("unchecked")
-  public static <R> R createExternalResource(Class<? extends Resource> resourceClass,
+  public static <R> R createResource(Class<? extends Resource> resourceClass,
           ResourceManager resMgr, Object... params) throws ResourceInitializationException {
     ExternalResourceDescription res = createExternalResourceDescription(resourceClass, params);
     return (R) produceResource(resourceClass, res.getResourceSpecifier(), resMgr, emptyMap());

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/ResourceManagerFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/ResourceManagerFactoryTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.uima.fit.factory;
 
-import static org.apache.uima.fit.factory.ExternalResourceFactory.createExternalResource;
+import static org.apache.uima.fit.factory.ExternalResourceFactory.createResource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.uima.fit.component.Resource_ImplBase;

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/ResourceManagerFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/ResourceManagerFactoryTest.java
@@ -32,7 +32,7 @@ public class ResourceManagerFactoryTest {
   
   @Test
   public void thatResourceCanBeCreated() throws Exception {
-    SimpleResource sut = createExternalResource(SimpleResource.class);
+    SimpleResource sut = createResource(SimpleResource.class);
     
     assertThat(sut).isInstanceOf(SimpleResource.class);
   }
@@ -44,7 +44,7 @@ public class ResourceManagerFactoryTest {
   
   @Test
   public void thatResourceCanBeParametrized() throws Exception {
-    ResourceWithParameters sut = createExternalResource(ResourceWithParameters.class,
+    ResourceWithParameters sut = createResource(ResourceWithParameters.class,
             "intValue", "1",
             "stringValue", "test");
     


### PR DESCRIPTION
- Adjusted name from createExternalResource to createResource since the latter would be the preferred name for uimaFIT v3.

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6186
