### PR TITLE
[UIMA-6204] createReaderDescription does not discover type priorities

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/CollectionReaderFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/CollectionReaderFactory.java
@@ -437,8 +437,10 @@ public final class CollectionReaderFactory {
 
   /**
    * A simple factory method for creating a CollectionReaderDescription with a given class, type
-   * system description, and configuration data The type system is detected automatically using
-   * {@link TypeSystemDescriptionFactory#createTypeSystemDescription()}.
+   * system description, and configuration data. The type system is detected automatically using
+   * {@link TypeSystemDescriptionFactory#createTypeSystemDescription()}. Type priorities are
+   * detected automatically using {@link TypePrioritiesFactory#createTypePriorities()}. Indexes are
+   * detected automatically using {@link FsIndexFactory#createFsIndexCollection()}.
    * 
    * @param readerClass
    *          The class of the CollectionReader to be created.
@@ -453,8 +455,11 @@ public final class CollectionReaderFactory {
   public static CollectionReaderDescription createReaderDescription(
           Class<? extends CollectionReader> readerClass, Object... configurationData)
           throws ResourceInitializationException {
-    TypeSystemDescription tsd = createTypeSystemDescription();
-    return createReaderDescription(readerClass, tsd, (TypePriorities) null, configurationData);
+    TypeSystemDescription typeSystem = createTypeSystemDescription();
+    TypePriorities typePriorities = createTypePriorities();
+    FsIndexCollection fsIndexCollection = createFsIndexCollection();
+    return createReaderDescription(readerClass, typeSystem, typePriorities, fsIndexCollection,
+            (Capability[]) null, configurationData);
   }
 
   /**

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypePrioritiesFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypePrioritiesFactoryTest.java
@@ -21,6 +21,7 @@ package org.apache.uima.fit.factory;
 
 import static org.apache.uima.fit.factory.TypePrioritiesFactory.createTypePriorities;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.uima.fit.type.Sentence;
@@ -54,8 +55,9 @@ public class TypePrioritiesFactoryTest {
     TypePriorities typePriorities = createTypePriorities();
 
     TypePriorityList[] typePrioritiesLists = typePriorities.getPriorityLists();
-    assertEquals(1, typePrioritiesLists.length);
-    assertEquals(Sentence.class.getName(), typePrioritiesLists[0].getTypes()[0]);
-    assertEquals(Token.class.getName(), typePrioritiesLists[0].getTypes()[1]);
+    assertThat(typePrioritiesLists.length).isEqualTo(1);
+    assertThat(typePrioritiesLists[0].getTypes())
+        .as("Type priorities auto-detection")
+        .containsExactly(Sentence.class.getName(), Token.class.getName());
   }
 }


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6204

- Auto-detect type priorities and index definitions in createReaderDescripton
- Added unit tests for auto-detection of types, prios and indexes to AnalysisEngineFactoryTest and CollectionReaderFactoryTest
- Ugraded a unit test in TypePrioritiesFactoryTest to assertj
