### PR TITLE
Aggregates with nested dependent AEs resource binding error example

### DIFF
--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/ExternalResourceFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/ExternalResourceFactoryTest.java
@@ -363,9 +363,12 @@ public class ExternalResourceFactoryTest extends ComponentTestBase {
     JCas jCas = JCasFactory.createJCas();
     jCas.setDocumentText("Hello");
     SimplePipeline.runPipeline(jCas, aggregateDescription);
+    int count = 0;
     for(AnalyzedText annotation: JCasUtil.select(jCas, AnalyzedText.class)) {
       Assert.assertEquals("World", annotation.getText());
+      count++;
     }
+    Assert.assertEquals(1, count);
   }
 
   public static class DummyResource implements SharedResourceObject {


### PR DESCRIPTION
There is no Jira issue reported yet, since , I am not sure if it's me doing something wrong in UIMA 3/UIMAfit 3 or whether it is an actual issue. This is just to illustrate the problem in uimaj-core 3.1.1 and uimaFit 3.0.0, which previously worked with uimaj-core-2.10.4 and uima-uimafit-2.4.0.

I've added a unit test to ExternalResourceFactoryTest, which should illustrate the problem. I haven't haven't tried to reuse existing AE and resource test classes, since I wasn't sure how to apply them for the purpose of this test, but it might be better to rewrite the test for more optimal re-use of existing test classes.

In the test I also added an alternative commented out line using the deprecated createExternalResourceDescription that works with uimaj-core-2.10.4 and uima-uimafit-2.4.0. Running the test with these older versions of the APIs should illustrate that the test will pass.

From my own observations I could see in org.apache.uima.resource.impl.ResourceManager_impl#resolveAndValidateResourceDependencies that the mResourceMap keys is different when running with the two versions. It appears that the resource map is not constructed with the proper qualified names in version 3.