### PR TITLE
Sync master v2 to master

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache UIMA uimaFIT
-Copyright 2013-2019 The Apache Software Foundation
+Copyright 2013-2020 The Apache Software Foundation
 
 Copyright 2009-2012 Regents of the University of Colorado.
 All rights reserved.

--- a/src/main/dist-bin/LICENSE
+++ b/src/main/dist-bin/LICENSE
@@ -203,9 +203,9 @@
 
 =======================================================================
 
-SPRING FRAMEWORK 4.3.22.RELEASE SUBCOMPONENTS:
+SPRING FRAMEWORK 4.3.26.RELEASE SUBCOMPONENTS:
 
-Spring Framework 4.3.22.RELEASE includes a number of subcomponents
+Spring Framework 4.3.26.RELEASE includes a number of subcomponents
 with separate copyright notices and license terms. The product that
 includes this file does not necessarily use all the open source
 subcomponents referred to below. Your use of the source
@@ -213,7 +213,7 @@ code for these subcomponents is subject to the terms and
 conditions of the following licenses.
 
 
->>> ASM 4.0 (org.ow2.asm:asm:4.0, org.ow2.asm:asm-commons:4.0):
+>>> ASM 6.0 (org.ow2.asm:asm:6.0, org.ow2.asm:asm-commons:6.0):
 
 Copyright (c) 2000-2011 INRIA, France Telecom
 All rights reserved.
@@ -245,36 +245,39 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
 
 
->>> CGLIB 3.0 (cglib:cglib:3.0):
+>>> CGLIB 3.2.6 (cglib:cglib:3.2.6):
 
 Per the LICENSE file in the CGLIB JAR distribution downloaded from
-http://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download,
-CGLIB 3.0 is licensed under the Apache License, version 2.0, the text of which
-is included above.
+https://github.com/cglib/cglib/releases/download/RELEASE_3_2_6/cglib-3.2.6.jar,
+CGLIB 3.2.6 is licensed under the Apache License, version 2.0, the text of
+which is included above.
 
 
-=======================================================================
+>>> Objenesis 2.6 (org.objenesis:objenesis:2.6):
 
-To the extent any open source subcomponents are licensed under the EPL and/or
+Per the LICENSE file in the Objenesis ZIP distribution downloaded from
+http://objenesis.org/download.html, Objenesis 2.6 is licensed under the
+Apache License, version 2.0, the text of which is included above.
+
+
+===============================================================================
+
+To the extent any open source components are licensed under the EPL and/or
 other similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a
 copy of the source code corresponding to the binaries for such open source
 components and modifications thereto, if any, (the "Source Files"), by
-downloading the Source Files from http://www.springsource.org/download, or by
-sending a request, with your name and address to:
+downloading the Source Files from https://spring.io/projects, Pivotal's website
+at https://network.pivotal.io/open-source, or by sending a request, with your
+name and address to: Pivotal Software, Inc., 875 Howard Street, 5th floor, San
+Francisco, CA 94103, Attention: General Counsel. All such requests should
+clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel. Pivotal
+can mail a copy of the Source Files to you on a CD or equivalent physical
+medium.
 
-    Pivotal, Inc., 875 Howard St,
-    San Francisco, CA 94103
-    United States of America
-
-or email info@pivotal.io.  All such requests should clearly specify:
-
-    OPEN SOURCE FILES REQUEST
-    Attention General Counsel
-
-Pivotal shall mail a copy of the Source Files to you on a CD or equivalent
-physical medium. This offer to obtain a copy of the Source Files is valid for
-three years from the date you acquired this Software product.
+This offer to obtain a copy of the Source Files is valid for three years from
+the date you acquired this Software product. Alternatively, the Source Files
+may accompany the Software.

--- a/src/main/dist-bin/NOTICE
+++ b/src/main/dist-bin/NOTICE
@@ -1,12 +1,15 @@
+----------------------------------------------------------------
+
 Apache UIMA uimaFIT
-Copyright 2012-2019 The Apache Software Foundation
+Copyright 2012-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+----------------------------------------------------------------
 
 Apache UIMA uimaFIT - Core
-Copyright 2013-2019 The Apache Software Foundation
+Copyright 2013-2020 The Apache Software Foundation
 
 Copyright 2009-2012 Regents of the University of Colorado.
 All rights reserved.
@@ -15,16 +18,18 @@ Copyright 2009-2012 Ubiquitous Knowledge Processing (UKP) Lab.
 Technische Universität Darmstadt.
 All rights reserved.
 
+----------------------------------------------------------------
 
 Apache UIMA uimaFIT - Collection Processing Engine support
 Apache UIMA uimaFIT - Legacy uimaFIT support
-Copyright 2012-2019 The Apache Software Foundation
+Copyright 2012-2020 The Apache Software Foundation
 
+----------------------------------------------------------------
 
-Apache UIMA Base: uimaj-core
-Apache UIMA Base: jVinci: Vinci Transport Library
-Apache UIMA Base: uimaj-adapter-vinci: Vinci Adapter
-Apache UIMA Base: uimaj-cpe: Collection Processing Engine
+Apache UIMA Base 3.1.1: uimaj-core
+Apache UIMA Base 3.1.1: jVinci: Vinci Transport Library
+Apache UIMA Base 3.1.1: uimaj-adapter-vinci: Vinci Adapter
+Apache UIMA Base 3.1.1: uimaj-cpe: Collection Processing Engine
 Copyright 2006-2019 The Apache Software Foundation
 
 Portions of Apache UIMA were originally developed by
@@ -34,21 +39,25 @@ licensed to the Apache Software Foundation under the
 "IBM UIMA License Agreement".
 Copyright (c) 2003, 2006 IBM Corporation.
 
+----------------------------------------------------------------
 
+<<<<<<< HEAD
 Apache Commons IO
 Copyright 2002-2017 The Apache Software Foundation
+=======
+Apache Commons IO 2.2
+Copyright 2002-2012 The Apache Software Foundation
+>>>>>>> master-v2
 
+----------------------------------------------------------------
 
-Apache Commons Lang
+Apache Commons Lang 3.8.1
 Copyright 2001-2018 The Apache Software Foundation
 
-
-Commons Logging
-Copyright 2003-2014 The Apache Software Foundation
+----------------------------------------------------------------
   
-  
-Spring Framework 4.3.22.RELEASE
-Copyright (c) 2002-2019 Pivotal, Inc.
+Spring Framework 4.3.26.RELEASE
+Copyright (c) 2002-2020 Pivotal, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with
@@ -59,6 +68,7 @@ copyright notices and license terms. Your use of the source code for
 these subcomponents is subject to the terms and conditions of the
 subcomponent's license, as noted in the license.txt file.
 
+----------------------------------------------------------------
 
 AnnotationLiteral.java
 

--- a/src/main/dist-bin/NOTICE
+++ b/src/main/dist-bin/NOTICE
@@ -41,19 +41,19 @@ Copyright (c) 2003, 2006 IBM Corporation.
 
 ----------------------------------------------------------------
 
-<<<<<<< HEAD
-Apache Commons IO
+Apache Commons IO 2.6
 Copyright 2002-2017 The Apache Software Foundation
-=======
-Apache Commons IO 2.2
-Copyright 2002-2012 The Apache Software Foundation
->>>>>>> master-v2
 
 ----------------------------------------------------------------
 
 Apache Commons Lang 3.8.1
 Copyright 2001-2018 The Apache Software Foundation
 
+----------------------------------------------------------------
+
+Commons Logging 1.2
+Copyright 2003-2014 The Apache Software Foundation
+  
 ----------------------------------------------------------------
   
 Spring Framework 4.3.26.RELEASE

--- a/uimafit-cpe/.settings/org.eclipse.core.resources.prefs
+++ b/uimafit-cpe/.settings/org.eclipse.core.resources.prefs
@@ -2,5 +2,4 @@ eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
 encoding//src/main/resources=UTF-8
 encoding//src/test/java=UTF-8
-encoding//src/test/resources=UTF-8
 encoding/<project>=UTF-8

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -32,7 +32,7 @@
   <url>${uimaWebsiteUrl}</url>
   <inceptionYear>2012</inceptionYear>
   <properties>
-    <spring.version>4.3.22.RELEASE</spring.version>
+    <spring.version>4.3.26.RELEASE</spring.version>
     <uima.version>3.0.2</uima.version>
     <slf4j.version>1.7.26</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
**[UIMA-6147] Upgrade to Spring 4**
- Upgraded to Spring 4.3.26
- Upgraded to UIMA Core 2.10.4
- Updated NOTICE and LICENSE file of the binary distribution
- Updated year in the copyright notice of the NOTICE file
- Added dependency-maven-plugin to check for too many/few dependencies

**Other**
- Update Eclipse metadata.