### PR TITLE
[UIMA-6222] XML-related unit test fails on Java 9+

### DIFF
--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/AnalysisEngineFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/AnalysisEngineFactoryTest.java
@@ -85,6 +85,7 @@ import org.apache.uima.resource.metadata.TypePriorityList;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.XMLInputSource;
 import org.custommonkey.xmlunit.XMLAssert;
+import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
 
 public class AnalysisEngineFactoryTest extends ComponentTestBase {
@@ -564,6 +565,7 @@ public class AnalysisEngineFactoryTest extends ComponentTestBase {
     
     String actual = FileUtils.readFileToString(target, "UTF-8");
     String expected = FileUtils.readFileToString(reference, "UTF-8");
+    XMLUnit.setIgnoreWhitespace(true);
     XMLAssert.assertXMLEqual(expected, actual);
 //    assertEquals(expected, actual);
   }
@@ -580,7 +582,6 @@ public class AnalysisEngineFactoryTest extends ComponentTestBase {
     PearSpecifier specifier = UIMAFramework.getXMLParser().parsePearSpecifier(in);
     
     AnalysisEngine ae = createEngine(createEngineDescription(specifier));
-    
     
     // Create a CAS with a sample document text and process the CAS   
     CAS cas = ae.newCAS();


### PR DESCRIPTION
- Ignore whitespace during XML comparison to run on recent JDKs

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6222
