### PR TITLE
[UIMA-6224] uimaFIT does not build on Java 14

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/package-info.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/package-info.java
@@ -19,7 +19,7 @@
 /**
  * Factories to create different kinds of UIMA resource specifiers.
  * 
- * <h3><a name="InstancesVsDescriptors">Why are descriptors better than component instances?</a></h3>
+ * <h2><a id="InstancesVsDescriptors">Why are descriptors better than component instances?</a></h2>
  * 
  * It is recommended to avoid instantiating components with uimaFIT outside of a running pipeline,
  * unless necessary and unless you are aware of the consequences.

--- a/uimafit-core/src/main/java/org/apache/uima/fit/util/package-info.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/util/package-info.java
@@ -19,14 +19,14 @@
 /**
  * Utility classes like {@link org.apache.uima.fit.util.CasUtil} and {@link org.apache.uima.fit.util.JCasUtil}.
  * 
- * <h3><a name="SortOrder">Sort order</a></h3>
+ * <H2><a id="SortOrder">Sort order</a></H2>
  * 
  * The various <em>select</em> methods in {@link org.apache.uima.fit.util.CasUtil} and 
  * {@link org.apache.uima.fit.util.JCasUtil} rely on the UIMA feature structure indexes. Their
  * behaviour differs depending on the type of feature structure being selected and where they are
  * selected from:
  * 
- * <h4>Selecting from a {@link org.apache.uima.cas.CAS}/{@link org.apache.uima.jcas.JCas}</h4>
+ * <H2>Selecting from a {@link org.apache.uima.cas.CAS}/{@link org.apache.uima.jcas.JCas}</H2>
  * <ol>
  * <li><b>Annotations</b> - if the type being selected is {@link org.apache.uima.jcas.tcas.Annotation}
  * or a sub-type thereof, the built-in annotation index is used. This index has the keys 
@@ -40,7 +40,7 @@
  * to access these feature structures.</li>
  * </ol>
  * 
- * <h4>Selecting from a {@link org.apache.uima.cas.ArrayFS ArrayFS/FSArray}/{@link org.apache.uima.jcas.cas.FSList}</h4>
+ * <H2>Selecting from a {@link org.apache.uima.cas.ArrayFS ArrayFS/FSArray}/{@link org.apache.uima.jcas.cas.FSList}</H2>
  * 
  * When selecting from a feature structure list or array, the order is determined by the order of
  * the annotations inside the list/array.

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -307,7 +307,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.1</version>
+          <version>3.0.0-M3</version>
           <executions>
             <execution>
               <id>enforce-prerequisites</id>
@@ -336,10 +336,22 @@
           <exists>marker-file-identifying-api-compatibility-check</exists>
         </file>
       </activation>
-      <properties>
-        <japicmp.postAnalysisScript>${project.basedir}/../uimafit-parent/src/main/groovy/api-report.groovy</japicmp.postAnalysisScript>
-      </properties>
       <build>
+        <plugins>
+          <!-- https://siom79.github.io/japicmp/MavenPlugin.html -->
+          <plugin>
+            <groupId>com.github.siom79.japicmp</groupId>
+            <artifactId>japicmp-maven-plugin</artifactId>
+            <version>0.14.3</version>
+            <configuration>
+              <parameter combine.children="append">
+                <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                <reportOnlyFilename>true</reportOnlyFilename>
+                <postAnalysisScript>${project.basedir}/../uimafit-parent/src/main/groovy/api-report.groovy</postAnalysisScript>
+              </parameter>
+            </configuration>
+          </plugin>
+        </plugins>
         <pluginManagement>
           <plugins>
             <plugin>


### PR DESCRIPTION
- Upgrade to Maven Enforcer plugin 3.0.0-M3 for recent Java JDK compatibility
- Upgrade to japicmp Maven plugin 0.14.3 for recent Java JDK compatibility
- Fixed out-of-sequence headers in JavaDoc
- Replace name with id attribute in anchors in JavaDoc

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6224
