### PR TITLE
[UIMA-6232] Reduce overhead of createTypeSystemDescription() and friends

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/FsIndexFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/FsIndexFactory.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,6 +26,7 @@ import static org.apache.uima.fit.internal.ReflectionUtil.getInheritableAnnotati
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.WeakHashMap;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.uima.fit.descriptor.FsIndex;
@@ -42,6 +43,7 @@ import org.apache.uima.resource.metadata.impl.FsIndexKeyDescription_impl;
 import org.apache.uima.resource.metadata.impl.Import_impl;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
+import org.springframework.util.ClassUtils;
 
 /**
  */
@@ -61,6 +63,17 @@ public final class FsIndexFactory {
 
   private static final Object SCAN_LOCK = new Object();
 
+  private static final Object CREATE_LOCK = new Object();
+
+  private static WeakHashMap<ClassLoader, String[]> fsIndexLocationsByClassloader;
+
+  private static WeakHashMap<ClassLoader, FsIndexCollection> fsIndexCollectionsByClassloader;
+
+  static {
+    fsIndexLocationsByClassloader = new WeakHashMap<>();
+    fsIndexCollectionsByClassloader = new WeakHashMap<>();
+  }
+
   private FsIndexFactory() {
     // Factory class
   }
@@ -68,13 +81,13 @@ public final class FsIndexFactory {
   /**
    * Create index configuration data for a given class definition using reflection and the
    * configuration parameter annotation.
-   * 
+   *
    * @param componentClass
    *          the class to analyze
    * @return the index collection
    */
   public static FsIndexCollection createFsIndexCollection(Class<?> componentClass) {
-    List<FsIndex> anFsIndexList = new ArrayList<FsIndex>();
+    List<FsIndex> anFsIndexList = new ArrayList<>();
 
     // Check FsIndexCollection annotation
     org.apache.uima.fit.descriptor.FsIndexCollection anIndexCollection = getInheritableAnnotation(
@@ -88,10 +101,10 @@ public final class FsIndexFactory {
             componentClass);
     if (anFsIndex != null) {
       if (anIndexCollection != null) {
-        throw new IllegalStateException("Class [" + componentClass.getName() + "] must not "
-                + "declare "
-                + org.apache.uima.fit.descriptor.FsIndexCollection.class.getSimpleName() + " and "
-                + FsIndex.class.getSimpleName() + " at the same time.");
+        throw new IllegalStateException(
+                "Class [" + componentClass.getName() + "] must not " + "declare "
+                        + org.apache.uima.fit.descriptor.FsIndexCollection.class.getSimpleName()
+                        + " and " + FsIndex.class.getSimpleName() + " at the same time.");
       }
 
       anFsIndexList.add(anFsIndex);
@@ -102,7 +115,7 @@ public final class FsIndexFactory {
     // Process collected FsIndex annotations
     for (FsIndex anIdx : anFsIndexList) {
       // Collect index keys
-      List<FsIndexKeyDescription> keys = new ArrayList<FsIndexKeyDescription>();
+      List<FsIndexKeyDescription> keys = new ArrayList<>();
       for (FsIndexKey anIndexKey : anIdx.keys()) {
         keys.add(createFsIndexKeyDescription(anIndexKey.featureName(), anIndexKey.comparator()));
       }
@@ -158,7 +171,7 @@ public final class FsIndexFactory {
 
   /**
    * Create a index collection from a set of descriptions.
-   * 
+   *
    * @param descriptions
    *          the index descriptions
    * @return the index collection
@@ -185,7 +198,8 @@ public final class FsIndexFactory {
    *          the index comparator
    * @return the index key description
    */
-  public static FsIndexKeyDescription createFsIndexKeyDescription(String featureName, int comparator) {
+  public static FsIndexKeyDescription createFsIndexKeyDescription(String featureName,
+          int comparator) {
     FsIndexKeyDescription_impl key = new FsIndexKeyDescription_impl();
     key.setFeatureName(featureName);
     key.setComparator(comparator);
@@ -193,17 +207,15 @@ public final class FsIndexFactory {
     return key;
   }
 
-  private static String[] indexDescriptorLocations;
-
   /**
    * Creates a {@link FsIndexCollection} from descriptor names.
-   * 
+   *
    * @param descriptorNames
    *          The fully qualified, Java-style, dotted descriptor names.
    * @return a {@link FsIndexCollection} that includes the indexes from all of the specified files.
    */
   public static FsIndexCollection createFsIndexCollection(String... descriptorNames) {
-    List<Import> imports = new ArrayList<Import>();
+    List<Import> imports = new ArrayList<>();
     for (String descriptorName : descriptorNames) {
       Import imp = new Import_impl();
       imp.setName(descriptorName);
@@ -218,13 +230,13 @@ public final class FsIndexFactory {
 
   /**
    * Creates a {@link FsIndexCollection} from a descriptor file
-   * 
+   *
    * @param descriptorURIs
    *          The descriptor file paths.
    * @return A {@link FsIndexCollection} that includes the indexes from all of the specified files.
    */
   public static FsIndexCollection createTypeSystemDescriptionFromPath(String... descriptorURIs) {
-    List<Import> imports = new ArrayList<Import>();
+    List<Import> imports = new ArrayList<>();
     for (String descriptorURI : descriptorURIs) {
       Import imp = new Import_impl();
       imp.setLocation(descriptorURI);
@@ -241,46 +253,59 @@ public final class FsIndexFactory {
    * Creates a {@link FsIndexCollection} from all index descriptions that can be found via the
    * pattern specified in the system property {@code org.apache.uima.fit.fsindex.import_pattern} or
    * via the {@code META-INF/org.apache.uima.fit/fsindexes.txt} files in the classpath.
-   * 
+   *
    * @return the auto-scanned indexes.
    * @throws ResourceInitializationException
    *           if the index collection could not be assembled
    */
   public static FsIndexCollection createFsIndexCollection() throws ResourceInitializationException {
-    List<FsIndexDescription> fsIndexList = new ArrayList<FsIndexDescription>();
-    for (String location : scanIndexDescriptors()) {
-      try {
-        XMLInputSource xmlInput = new XMLInputSource(location);
-        FsIndexCollection fsIdxCol = getXMLParser().parseFsIndexCollection(xmlInput);
-        fsIdxCol.resolveImports();
-        fsIndexList.addAll(asList(fsIdxCol.getFsIndexes()));
-        LogFactory.getLog(FsIndexFactory.class).debug("Detected index at [" + location + "]");
-      } catch (IOException e) {
-        throw new ResourceInitializationException(e);
-      } catch (InvalidXMLException e) {
-        LogFactory.getLog(FsIndexFactory.class).warn(
-                "[" + location + "] is not a index descriptor file. Ignoring.", e);
+    ClassLoader cl = ClassUtils.getDefaultClassLoader();
+    FsIndexCollection aggFsIdxCol = fsIndexCollectionsByClassloader.get(cl);
+    if (aggFsIdxCol == null) {
+      synchronized (CREATE_LOCK) {
+        List<FsIndexDescription> fsIndexList = new ArrayList<>();
+        for (String location : scanIndexDescriptors()) {
+          try {
+            XMLInputSource xmlInput = new XMLInputSource(location);
+            FsIndexCollection fsIdxCol = getXMLParser().parseFsIndexCollection(xmlInput);
+            fsIdxCol.resolveImports();
+            fsIndexList.addAll(asList(fsIdxCol.getFsIndexes()));
+            LogFactory.getLog(FsIndexFactory.class).debug("Detected index at [" + location + "]");
+          } catch (IOException e) {
+            throw new ResourceInitializationException(e);
+          } catch (InvalidXMLException e) {
+            LogFactory.getLog(FsIndexFactory.class)
+                    .warn("[" + location + "] is not a index descriptor file. Ignoring.", e);
+          }
+        }
+
+        aggFsIdxCol = createFsIndexCollection(
+                fsIndexList.toArray(new FsIndexDescription[fsIndexList.size()]));
+        fsIndexCollectionsByClassloader.put(cl, aggFsIdxCol);
       }
     }
 
-    return createFsIndexCollection(fsIndexList.toArray(new FsIndexDescription[fsIndexList.size()]));
+    return (FsIndexCollection) aggFsIdxCol.clone();
   }
 
   /**
    * Get all currently accessible index descriptor locations. A scan is actually only performed on
    * the first call and the locations are cached. To force a re-scan use
    * {@link #forceIndexDescriptorsScan()}.
-   * 
+   *
    * @return an array of locations.
    * @throws ResourceInitializationException
    *           if the locations could not be resolved.
    */
   public static String[] scanIndexDescriptors() throws ResourceInitializationException {
     synchronized (SCAN_LOCK) {
-      if (indexDescriptorLocations == null) {
-        indexDescriptorLocations = scanDescriptors(MetaDataType.FS_INDEX);
+      ClassLoader cl = ClassUtils.getDefaultClassLoader();
+      String[] indexLocations = fsIndexLocationsByClassloader.get(cl);
+      if (indexLocations == null) {
+        indexLocations = scanDescriptors(MetaDataType.FS_INDEX);
+        fsIndexLocationsByClassloader.put(cl, indexLocations);
       }
-      return indexDescriptorLocations;
+      return indexLocations;
     }
   }
 
@@ -289,6 +314,9 @@ public final class FsIndexFactory {
    * all auto-import locations.
    */
   public static void forceIndexDescriptorsScan() {
-    indexDescriptorLocations = null;
+    synchronized (SCAN_LOCK) {
+      fsIndexLocationsByClassloader.clear();
+      fsIndexCollectionsByClassloader.clear();
+    }
   }
 }

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@ import static org.apache.uima.fit.util.CasUtil.UIMA_BUILTIN_JCAS_PREFIX;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.WeakHashMap;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.uima.fit.internal.MetaDataType;
@@ -37,14 +38,21 @@ import org.apache.uima.resource.metadata.impl.TypePriorities_impl;
 import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
-
-/**
- */
+import org.springframework.util.ClassUtils;
 
 public final class TypePrioritiesFactory {
   private static final Object SCAN_LOCK = new Object();
 
-  private static String[] typePriorityDescriptorLocations;
+  private static final Object CREATE_LOCK = new Object();
+
+  private static WeakHashMap<ClassLoader, String[]> typePrioritesLocationsByClassloader;
+
+  private static WeakHashMap<ClassLoader, TypePriorities> typePrioritiesByClassloader;
+
+  static {
+    typePrioritesLocationsByClassloader = new WeakHashMap<>();
+    typePrioritiesByClassloader = new WeakHashMap<>();
+  }
 
   private TypePrioritiesFactory() {
     // This class is not meant to be instantiated
@@ -52,7 +60,7 @@ public final class TypePrioritiesFactory {
 
   /**
    * Create a TypePriorities given a sequence of ordered type classes
-   * 
+   *
    * @param prioritizedTypes
    *          a sequence of ordered type classes
    * @return type priorities created from the ordered JCas classes
@@ -71,8 +79,8 @@ public final class TypePrioritiesFactory {
   }
 
   /**
-   * Create a TypePriorities given a sequence of ordered type names
-   * 
+   * Create a {@link TypePriorities} given a sequence of ordered type names
+   *
    * @param prioritizedTypeNames
    *          a sequence of ordered type names
    * @return type priorities created from the ordered type names
@@ -91,51 +99,60 @@ public final class TypePrioritiesFactory {
    * the pattern specified in the system property
    * {@code org.apache.uima.fit.typepriorities.import_pattern} or via the
    * {@code META-INF/org.apache.uima.fit/typepriorities.txt} files in the classpath.
-   * 
+   *
    * @return the auto-scanned type priorities.
    * @throws ResourceInitializationException
    *           if the collected type priorities cannot be merged.
    */
   public static TypePriorities createTypePriorities() throws ResourceInitializationException {
-    List<TypePriorities> typePrioritiesList = new ArrayList<TypePriorities>();
-    for (String location : scanTypePrioritiesDescriptors()) {
-      try {
-        XMLInputSource xmlInput = new XMLInputSource(location);
-        TypePriorities typePriorities = getXMLParser().parseTypePriorities(xmlInput);
-        typePriorities.resolveImports();
-        typePrioritiesList.add(typePriorities);
-        LogFactory.getLog(TypePrioritiesFactory.class).debug(
-                "Detected type priorities at [" + location + "]");
-      } catch (IOException e) {
-        throw new ResourceInitializationException(e);
-      } catch (InvalidXMLException e) {
-        LogFactory.getLog(TypePrioritiesFactory.class).warn(
-                "[" + location + "] is not a type priorities descriptor file. Ignoring.", e);
+    ClassLoader cl = ClassUtils.getDefaultClassLoader();
+    TypePriorities aggTypePriorities = typePrioritiesByClassloader.get(cl);
+    if (aggTypePriorities == null) {
+      synchronized (CREATE_LOCK) {
+        List<TypePriorities> typePrioritiesList = new ArrayList<>();
+        for (String location : scanTypePrioritiesDescriptors()) {
+          try {
+            XMLInputSource xmlInput = new XMLInputSource(location);
+            TypePriorities typePriorities = getXMLParser().parseTypePriorities(xmlInput);
+            typePriorities.resolveImports();
+            typePrioritiesList.add(typePriorities);
+            LogFactory.getLog(TypePrioritiesFactory.class)
+                    .debug("Detected type priorities at [" + location + "]");
+          } catch (IOException e) {
+            throw new ResourceInitializationException(e);
+          } catch (InvalidXMLException e) {
+            LogFactory.getLog(TypePrioritiesFactory.class).warn(
+                    "[" + location + "] is not a type priorities descriptor file. Ignoring.", e);
+          }
+        }
+
+        ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
+        aggTypePriorities = CasCreationUtils.mergeTypePriorities(typePrioritiesList, resMgr);
+        typePrioritiesByClassloader.put(cl, aggTypePriorities);
       }
     }
 
-    ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
-    TypePriorities aggTypePriorities = CasCreationUtils.mergeTypePriorities(typePrioritiesList,
-            resMgr);
-
-    return aggTypePriorities;
+    return (TypePriorities) aggTypePriorities.clone();
   }
 
   /**
    * Get all currently accessible type priorities descriptor locations. A scan is actually only
    * performed on the first call and the locations are cached. To force a re-scan use
    * {@link #forceTypePrioritiesDescriptorsScan()}.
-   * 
+   *
    * @return an array of locations.
    * @throws ResourceInitializationException
    *           if the locations could not be resolved.
    */
   public static String[] scanTypePrioritiesDescriptors() throws ResourceInitializationException {
     synchronized (SCAN_LOCK) {
-      if (typePriorityDescriptorLocations == null) {
-        typePriorityDescriptorLocations = scanDescriptors(MetaDataType.TYPE_PRIORITIES);
+      ClassLoader cl = ClassUtils.getDefaultClassLoader();
+      String[] typePrioritesLocations = typePrioritesLocationsByClassloader.get(cl);
+      if (typePrioritesLocations == null) {
+        typePrioritesLocations = scanDescriptors(MetaDataType.TYPE_PRIORITIES);
+        typePrioritesLocationsByClassloader.put(cl, typePrioritesLocations);
       }
-      return typePriorityDescriptorLocations;
+      return typePrioritesLocations;
     }
   }
 
@@ -144,6 +161,9 @@ public final class TypePrioritiesFactory {
    * {@link #scanTypePrioritiesDescriptors()} will rescan all auto-import locations.
    */
   public static void forceTypePrioritiesDescriptorsScan() {
-    typePriorityDescriptorLocations = null;
+    synchronized (SCAN_LOCK) {
+      typePrioritesLocationsByClassloader.clear();
+      typePrioritiesByClassloader.clear();
+    }
   }
 }

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@ import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.WeakHashMap;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.uima.fit.internal.MetaDataType;
@@ -37,13 +38,21 @@ import org.apache.uima.resource.metadata.impl.Import_impl;
 import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
+import org.springframework.util.ClassUtils;
 
-/**
- */
 public final class TypeSystemDescriptionFactory {
   private static final Object SCAN_LOCK = new Object();
 
-  private static String[] typeDescriptorLocations;
+  private static final Object CREATE_LOCK = new Object();
+
+  private static WeakHashMap<ClassLoader, String[]> typeDescriptorLocationsByClassloader;
+
+  private static WeakHashMap<ClassLoader, TypeSystemDescription> typeDescriptorByClassloader;
+
+  static {
+    typeDescriptorLocationsByClassloader = new WeakHashMap<>();
+    typeDescriptorByClassloader = new WeakHashMap<>();
+  }
 
   private TypeSystemDescriptionFactory() {
     // This class is not meant to be instantiated
@@ -51,14 +60,14 @@ public final class TypeSystemDescriptionFactory {
 
   /**
    * Creates a TypeSystemDescription from descriptor names.
-   * 
+   *
    * @param descriptorNames
    *          The fully qualified, Java-style, dotted descriptor names.
    * @return A TypeSystemDescription that includes the types from all of the specified files.
    */
   public static TypeSystemDescription createTypeSystemDescription(String... descriptorNames) {
     TypeSystemDescription typeSystem = new TypeSystemDescription_impl();
-    List<Import> imports = new ArrayList<Import>();
+    List<Import> imports = new ArrayList<>();
     for (String descriptorName : descriptorNames) {
       Import imp = new Import_impl();
       imp.setName(descriptorName);
@@ -70,15 +79,16 @@ public final class TypeSystemDescriptionFactory {
   }
 
   /**
-   * Creates a TypeSystemDescription from a descriptor file
-   * 
+   * Creates a {@link TypeSystemDescription} from a descriptor file
+   *
    * @param descriptorURIs
    *          The descriptor file paths.
    * @return A TypeSystemDescription that includes the types from all of the specified files.
    */
-  public static TypeSystemDescription createTypeSystemDescriptionFromPath(String... descriptorURIs) {
+  public static TypeSystemDescription createTypeSystemDescriptionFromPath(
+          String... descriptorURIs) {
     TypeSystemDescription typeSystem = new TypeSystemDescription_impl();
-    List<Import> imports = new ArrayList<Import>();
+    List<Import> imports = new ArrayList<>();
     for (String descriptorURI : descriptorURIs) {
       Import imp = new Import_impl();
       imp.setLocation(descriptorURI);
@@ -93,45 +103,56 @@ public final class TypeSystemDescriptionFactory {
    * Creates a {@link TypeSystemDescription} from all type descriptions that can be found via the
    * default import pattern or via the {@code META-INF/org.apache.uima.fit/types.txt} files in the
    * classpath.
-   * 
+   *
    * @return the auto-scanned type system.
    * @throws ResourceInitializationException
    *           if the collected type system descriptions cannot be merged.
    */
   public static TypeSystemDescription createTypeSystemDescription()
           throws ResourceInitializationException {
-    List<TypeSystemDescription> tsdList = new ArrayList<TypeSystemDescription>();
-    for (String location : scanTypeDescriptors()) {
-      try {
-        XMLInputSource xmlInputType1 = new XMLInputSource(location);
-        tsdList.add(getXMLParser().parseTypeSystemDescription(xmlInputType1));
-        LogFactory.getLog(TypeSystemDescription.class).debug(
-                "Detected type system at [" + location + "]");
-      } catch (IOException e) {
-        throw new ResourceInitializationException(e);
-      } catch (InvalidXMLException e) {
-        LogFactory.getLog(TypeSystemDescription.class).warn(
-                "[" + location + "] is not a type file. Ignoring.", e);
+    ClassLoader cl = ClassUtils.getDefaultClassLoader();
+    TypeSystemDescription tsd = typeDescriptorByClassloader.get(cl);
+    if (tsd == null) {
+      synchronized (CREATE_LOCK) {
+        List<TypeSystemDescription> tsdList = new ArrayList<>();
+        for (String location : scanTypeDescriptors()) {
+          try {
+            XMLInputSource xmlInputType1 = new XMLInputSource(location);
+            tsdList.add(getXMLParser().parseTypeSystemDescription(xmlInputType1));
+            LogFactory.getLog(TypeSystemDescription.class)
+                .debug("Detected type system at [" + location + "]");
+          } catch (IOException e) {
+            throw new ResourceInitializationException(e);
+          } catch (InvalidXMLException e) {
+            LogFactory.getLog(TypeSystemDescription.class)
+                .warn("[" + location + "] is not a type file. Ignoring.", e);
+          }
+        }
+
+        ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
+        tsd = mergeTypeSystems(tsdList, resMgr);
+        typeDescriptorByClassloader.put(cl, tsd);
       }
     }
-
-    ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
-    return mergeTypeSystems(tsdList, resMgr);
+    return (TypeSystemDescription) tsd.clone();
   }
 
   /**
    * Get all currently accessible type system descriptor locations. A scan is actually only
    * performed on the first call and the locations are cached. To force a re-scan use
    * {@link #forceTypeDescriptorsScan()}.
-   * 
+   *
    * @return an array of locations.
    * @throws ResourceInitializationException
    *           if the locations could not be resolved.
    */
   public static String[] scanTypeDescriptors() throws ResourceInitializationException {
     synchronized (SCAN_LOCK) {
+      ClassLoader cl = ClassUtils.getDefaultClassLoader();
+      String[] typeDescriptorLocations = typeDescriptorLocationsByClassloader.get(cl);
       if (typeDescriptorLocations == null) {
         typeDescriptorLocations = scanDescriptors(MetaDataType.TYPE_SYSTEM);
+        typeDescriptorLocationsByClassloader.put(cl, typeDescriptorLocations);
       }
       return typeDescriptorLocations;
     }
@@ -142,6 +163,9 @@ public final class TypeSystemDescriptionFactory {
    * all auto-import locations.
    */
   public static void forceTypeDescriptorsScan() {
-    typeDescriptorLocations = null;
+    synchronized (SCAN_LOCK) {
+      typeDescriptorLocationsByClassloader.clear();
+      typeDescriptorByClassloader.clear();
+    }
   }
 }

--- a/uimafit-core/src/main/java/org/apache/uima/fit/internal/MetaDataUtil.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/internal/MetaDataUtil.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -45,7 +45,7 @@ public final class MetaDataUtil {
 
   /**
    * Scan patterns from manifest files and from the specified system property.
-   * 
+   *
    * @param aType
    *          the type of metadata to scan for
    * @return array or all patterns found.
@@ -54,7 +54,7 @@ public final class MetaDataUtil {
    */
   public static String[] scanImportsAndManifests(MetaDataType aType)
           throws ResourceInitializationException {
-    ArrayList<String> patterns = new ArrayList<String>();
+    ArrayList<String> patterns = new ArrayList<>();
 
     // Scan auto-import locations
     for (String property : getImportProperties(aType)) {
@@ -80,7 +80,7 @@ public final class MetaDataUtil {
 
   /**
    * Resolve a list of patterns to a set of URLs.
-   * 
+   *
    * @param patterns
    *          the patterns to resolve
    * @return an array of locations.
@@ -88,11 +88,11 @@ public final class MetaDataUtil {
    *           if the locations could not be resolved.
    */
   public static String[] resolve(String... patterns) throws ResourceInitializationException {
-    Set<String> locations = new HashSet<String>();
+    Set<String> locations = new HashSet<>();
     PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
     try {
       // Scan auto-import locations. Using a set to avoid scanning a pattern twice.
-      for (String pattern : new TreeSet<String>(Arrays.asList(patterns))) {
+      for (String pattern : new TreeSet<>(Arrays.asList(patterns))) {
         String p = pattern.trim();
         if (p.length() == 0) {
           continue;
@@ -109,13 +109,13 @@ public final class MetaDataUtil {
 
   /**
    * Get manifest locations for the specified type.
-   * 
+   *
    * @param aType
    *          the type of metadata to scan for
    * @return the manifest locations for this kind of metadata to scan
    */
   public static String[] getManifestLocations(MetaDataType aType) {
-    List<String> locations = new ArrayList<String>();
+    List<String> locations = new ArrayList<>();
     switch (aType) {
       case FS_INDEX:
         locations.add("classpath*:META-INF/org.apache.uima.fit/fsindexes.txt");
@@ -125,7 +125,7 @@ public final class MetaDataUtil {
         break;
       case TYPE_PRIORITIES:
         locations.add("classpath*:META-INF/org.apache.uima.fit/typepriorities.txt");
-        break;        
+        break;
     }
 
     return locations.toArray(new String[locations.size()]);
@@ -134,13 +134,13 @@ public final class MetaDataUtil {
   /**
    * Get system properties indicating which locations to scan for descriptions of the given type. A
    * list of locations may be given separated by ";".
-   * 
+   *
    * @param aType
    *          the type of metadata to scan for
    * @return the locations for this kind of metadata to scan
    */
   public static String[] getImportProperties(MetaDataType aType) {
-    List<String> locations = new ArrayList<String>();
+    List<String> locations = new ArrayList<>();
     switch (aType) {
       case FS_INDEX:
         locations.add("org.apache.uima.fit.fsindex.import_pattern");
@@ -150,18 +150,18 @@ public final class MetaDataUtil {
         break;
       case TYPE_PRIORITIES:
         locations.add("org.apache.uima.fit.typepriorities.import_pattern");
-        break;        
+        break;
     }
 
     return locations.toArray(new String[locations.size()]);
   }
-  
+
   /**
    * Get all currently accessible descriptor locations for the given type.
-   * 
+   *
    * @param aType
    *          the type of metadata to scan for
-      * @return an array of locations.
+   * @return an array of locations.
    * @throws ResourceInitializationException
    *           if the locations could not be resolved.
    */


### PR DESCRIPTION
- Set up caches for the descriptor locations based on the ClassLoader being used
- Set up caches for the parsed and aggregated descriptors and return cloned versions when being asked for them

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6232
