### PR TITLE
[UIMA-6286] select following finds zero-width annotation at reference end position

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/util/CasUtil.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/util/CasUtil.java
@@ -1180,8 +1180,17 @@ public final class CasUtil {
     }
 
     // add annotations from the iterator into the result list
+    int refEnd = annotation.getEnd();
     List<AnnotationFS> followingAnnotations = new LinkedList<AnnotationFS>();
     for (int i = 0; i < count && itr.isValid(); i++, itr.moveToNext()) {
+      AnnotationFS fs = itr.get();
+      int begin = fs.getBegin();
+      int end = fs.getEnd();
+      if (begin == end && refEnd == begin) {
+        // Skip zero-width annotation at the end of the reference annotation. These are considered
+        // to be "coveredBy" instead of following
+        continue;
+      }
       followingAnnotations.add(itr.get());
     }
     return followingAnnotations;

--- a/uimafit-core/src/test/java/org/apache/uima/fit/util/JCasUtilTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/util/JCasUtilTest.java
@@ -21,6 +21,7 @@
  */
 package org.apache.uima.fit.util;
 
+import static java.lang.Integer.MAX_VALUE;
 import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.apache.uima.fit.util.JCasUtil.contains;
@@ -41,6 +42,7 @@ import static org.apache.uima.fit.util.JCasUtil.selectSingle;
 import static org.apache.uima.fit.util.JCasUtil.selectSingleAt;
 import static org.apache.uima.fit.util.JCasUtil.selectSingleRelative;
 import static org.apache.uima.fit.util.JCasUtil.toText;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -665,6 +667,34 @@ public class JCasUtilTest extends ComponentTestBase {
     assertEquals(Arrays.asList(c, d), following);
   }
 
+  @Test
+  public void thatSelectFollowingDoesNotFindZeroWidthAnnotationAtEnd()
+  {
+    Annotation a1 = new Annotation(jCas, 10, 20);
+    Annotation a2 = new Annotation(jCas, 20, 20);
+    
+    asList(a1, a2).forEach(a -> a.addToIndexes());
+    
+    List<Annotation> selection = selectFollowing(Annotation.class, a1, MAX_VALUE);
+    
+    assertThat(selection)
+            .isEmpty();
+  }
+
+  @Test
+  public void thatSelectPrecedingDoesNotFindZeroWidthAnnotationAtStart()
+  {
+    Annotation a1 = new Annotation(jCas, 10, 20);
+    Annotation a2 = new Annotation(jCas, 10, 10);
+    
+    asList(a1, a2).forEach(a -> a.addToIndexes());
+    
+    List<Annotation> selection = selectPreceding(Annotation.class, a1, MAX_VALUE);
+    
+    assertThat(selection)
+            .isEmpty();
+  }
+    
   @Test
   public void testExists() throws UIMAException {
     JCas jcas = CasCreationUtils.createCas(createTypeSystemDescription(), null, null).getJCas();


### PR DESCRIPTION
- When selecting following annotations, skip over zero-width annotations that are the the end position of the reference interval
- Added unit test checking behavior for zero-width annotations at start/end of reference when selecting following and preceding

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6286
