### PR TITLE
[UIMA-6292] selectCovering is slow

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/util/CasUtil.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/util/CasUtil.java
@@ -42,7 +42,6 @@ import org.apache.uima.cas.CASRuntimeException;
 import org.apache.uima.cas.FSIterator;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
-import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.cas.impl.Subiterator;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.cas.text.AnnotationIndex;
@@ -715,16 +714,15 @@ public final class CasUtil {
    */
   public static List<AnnotationFS> selectCovering(CAS cas, Type type, int begin, int end) {
 
-    TypeSystem ts = cas.getTypeSystem();
     List<AnnotationFS> list = new ArrayList<AnnotationFS>();
     
     // withSnapshotIterators() not needed here since we copy the FSes to a list anyway    
-    FSIterator<AnnotationFS> iter = cas.getAnnotationIndex().iterator();
+    FSIterator<AnnotationFS> iter = type == null ? cas.getAnnotationIndex().iterator()
+            : cas.getAnnotationIndex(type).iterator();
     
     while (iter.hasNext()) {
       AnnotationFS a = iter.next();
-      if ((a.getBegin() <= begin) && (a.getEnd() >= end)
-              && ((type == null) || (ts.subsumes(type, a.getType())))) {
+      if ((a.getBegin() <= begin) && (a.getEnd() >= end)) {
         list.add(a);
       }
     }


### PR DESCRIPTION
- Avoid repeatedly calling ts.subsumes by obtaining a properly-typed index in the first place.

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6292
