### PR TITLE
[UIMA-6291] Improve uimaFIT benchmarking module

### DIFF
--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/Benchmark.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/Benchmark.java
@@ -189,7 +189,7 @@ public class Benchmark {
   }
 
   /** Get CPU time in nanoseconds. */
-  public static long cpu( ) {
+  public static long cpuTime( ) {
     ThreadMXBean bean = ManagementFactory.getThreadMXBean( );
     if(bean.isCurrentThreadCpuTimeSupported( )) {
       return bean.getCurrentThreadCpuTime( );
@@ -198,7 +198,7 @@ public class Benchmark {
   }
 
   /** Get user time in nanoseconds. */
-  public static long user( ) {
+  public static long userTime( ) {
     ThreadMXBean bean = ManagementFactory.getThreadMXBean( );
     if(bean.isCurrentThreadCpuTimeSupported( )) {
       return bean.getCurrentThreadUserTime();
@@ -207,7 +207,7 @@ public class Benchmark {
   }
 
   /** Get static system time in nanoseconds. */
-  public static long system( ) {
+  public static long systemTime( ) {
     ThreadMXBean bean = ManagementFactory.getThreadMXBean( );
     if(bean.isCurrentThreadCpuTimeSupported( )) {
       return bean.getCurrentThreadCpuTime( ) - bean.getCurrentThreadUserTime( );

--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/BenchmarkGroup.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/BenchmarkGroup.java
@@ -49,8 +49,8 @@ public class BenchmarkGroup {
         .sorted(comparing(Benchmark::getCumulativeDuration))
         .forEach(benchmark -> {
           Measurement slowest = benchmark.getSlowestMeasurement();
-          System.out.printf("%6dms / %4dms -- %s%n", benchmark.getCumulativeDuration(), slowest.getDuration(),
-              benchmark.getName());
+          System.out.printf("%6d%s / %4d%s -- %s%n", benchmark.getCumulativeDuration(), benchmark.getTimerUnit(),
+                  slowest.getDuration(), benchmark.getTimerUnit(), benchmark.getName());
         });
 
     System.out.printf(">>>>>>>>>>>>>>>>>>%n%n");

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -154,6 +154,21 @@ public class SelectBenchmark {
                         .filter(t -> coveredBy(t, s))
                         .forEach(t -> {}));
             }))
+        .add(new Benchmark("JCAS.select(Token.class).coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().select(Token.class).coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().getAnnotationIndex(Token.class).select().coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
+        .add(new Benchmark("selectCovered(JCAS, Token.class, s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        selectCovered(casProvider.get(), Token.class, s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
         .runAll();
   }
   

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -46,6 +46,8 @@ public class SelectBenchmark {
 
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(1_000)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -75,6 +77,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -111,6 +115,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -157,6 +163,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -223,6 +231,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -46,7 +46,7 @@ public class SelectBenchmark {
 
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(1_000)
         .magnitude(10)
@@ -79,7 +79,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
@@ -117,7 +117,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
@@ -180,7 +180,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
@@ -248,7 +248,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -68,6 +68,8 @@ public class SelectBenchmark {
             .measure(() -> JCasUtil.select(casProvider.get(), Token.class).forEach(x -> {})))
         .add(new Benchmark("JCAS.select(Token.class).forEach(x -> {})", template)
             .measure(() -> casProvider.get().select(Token.class).forEach(x -> {})))
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().forEach(x -> {})", template)
+            .measure(() -> casProvider.get().getAnnotationIndex(Token.class).select().forEach(x -> {})))
         .runAll();
   }
 
@@ -285,6 +287,16 @@ public class SelectBenchmark {
                         .filter(t -> colocated(t, s))
                         .forEach(t -> {}));
             }))
-        .runAll();  
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().getAnnotationIndex(Token.class).select().at(s).forEach(t -> {}));
+            }))
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().getAnnotationIndex(Token.class).select().at(s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
+        .runAll();
   }
 }


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6291

- Added select and selectAt benchmarks using getAnnotationIndex approach.
- Added more selectCovered benchmarks with s.getBegin() and s.getEnd().
- Added support for nanoseconds CPU time support in Benchmark and changed SelectBenchmark to use user time.
