### PR TITLE
[UIMA-6291] Improve uimaFIT benchmarking module

### DIFF
--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/Batch.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/Batch.java
@@ -21,51 +21,33 @@ package org.apache.uima.fit.benchmark;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-
 public class Batch {
-    private List<Measurement> measurements = new ArrayList<>();
-    
-    private final int magnitude;
-    
-    public Batch(int aMagnitude) {
-      magnitude = aMagnitude;
-    }
-    
-    public int getMagnitude() {
-      return magnitude;
-    }
-    
-    public void addMeasurement(Measurement aMeasurement) {
-      measurements.add(aMeasurement);
-    }
-    
-    public List<Measurement> getMeasurements() {
-      return measurements;
-    }
-    
-    @Override
-    public String toString()
-    {
-      DescriptiveStatistics stats = new DescriptiveStatistics();
-      
-      StringBuilder sb = new StringBuilder();
-      sb.append("[").append(String.format("%7d/%7d", magnitude, measurements.size())).append(": ");
-      int failures = 0;
-      for (Measurement m : measurements) {
-        if (m.failed()) {
-          failures++;
-        }
-        else {
-          stats.addValue(m.getDuration());
-        }
-      }
-      sb.append(String.format("min: %4.0f ", stats.getMin()));
-      sb.append(String.format("max: %4.0f ", stats.getMax()));
-      sb.append(String.format("median: %4.0f ", stats.getPercentile(50)));
-      sb.append(String.format("cumulative: %6.0f ", stats.getSum()));
-      sb.append(String.format("fail: %4d ", failures));
-      sb.append("]");
-      return sb.toString();
-    }
+  private List<Measurement> measurements = new ArrayList<>();
+
+  private final int magnitude;
+  private boolean timeLimitExceeded;
+
+  public Batch(int aMagnitude) {
+    magnitude = aMagnitude;
   }
+
+  public int getMagnitude() {
+    return magnitude;
+  }
+
+  public void addMeasurement(Measurement aMeasurement) {
+    measurements.add(aMeasurement);
+  }
+
+  public List<Measurement> getMeasurements() {
+    return measurements;
+  }
+  
+  public void setTimeLimitExceeded(boolean aTimeLimitExceeded) {
+    timeLimitExceeded = aTimeLimitExceeded;
+  }
+  
+  public boolean isTimeLimitExceeded() {
+    return timeLimitExceeded;
+  }
+}

--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/Benchmark.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/Benchmark.java
@@ -189,7 +189,7 @@ public class Benchmark {
   }
 
   /** Get CPU time in nanoseconds. */
-  public static long cpu( ) {
+  public static long cpuTime( ) {
     ThreadMXBean bean = ManagementFactory.getThreadMXBean( );
     if(bean.isCurrentThreadCpuTimeSupported( )) {
       return bean.getCurrentThreadCpuTime( );
@@ -198,7 +198,7 @@ public class Benchmark {
   }
 
   /** Get user time in nanoseconds. */
-  public static long user( ) {
+  public static long userTime( ) {
     ThreadMXBean bean = ManagementFactory.getThreadMXBean( );
     if(bean.isCurrentThreadCpuTimeSupported( )) {
       return bean.getCurrentThreadUserTime();
@@ -207,7 +207,7 @@ public class Benchmark {
   }
 
   /** Get static system time in nanoseconds. */
-  public static long system( ) {
+  public static long systemTime( ) {
     ThreadMXBean bean = ManagementFactory.getThreadMXBean( );
     if(bean.isCurrentThreadCpuTimeSupported( )) {
       return bean.getCurrentThreadCpuTime( ) - bean.getCurrentThreadUserTime( );

--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/BenchmarkGroup.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/BenchmarkGroup.java
@@ -49,8 +49,8 @@ public class BenchmarkGroup {
         .sorted(comparing(Benchmark::getCumulativeDuration))
         .forEach(benchmark -> {
           Measurement slowest = benchmark.getSlowestMeasurement();
-          System.out.printf("%6dms / %4dms -- %s%n", benchmark.getCumulativeDuration(), slowest.getDuration(),
-              benchmark.getName());
+          System.out.printf("%6d%s / %4d%s -- %s%n", benchmark.getCumulativeDuration(), benchmark.getTimerUnit(),
+                  slowest.getDuration(), benchmark.getTimerUnit(), benchmark.getName());
         });
 
     System.out.printf(">>>>>>>>>>>>>>>>>>%n%n");

--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/BenchmarkGroup.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/BenchmarkGroup.java
@@ -18,27 +18,43 @@
  */
 package org.apache.uima.fit.benchmark;
 
+import static java.lang.Math.round;
 import static java.util.Comparator.comparing;
+import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationWords;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class BenchmarkGroup {
   private final String name;
+  private final Benchmark template;
   private final List<Benchmark> benchmarks = new ArrayList<>();
 
-  public BenchmarkGroup(String aName) {
+  public BenchmarkGroup(String aName, Benchmark aTemplate) {
     name = aName;
+    template = aTemplate;
+  }
+
+  public BenchmarkGroup addIgnoringTemplate(Benchmark aBenchmark) {
+    benchmarks.add(aBenchmark);
+    return this;
   }
 
   public BenchmarkGroup add(Benchmark aBenchmark) {
+    if (template != null) {
+      aBenchmark.applyTemplate(template);
+    }
     benchmarks.add(aBenchmark);
     return this;
   }
 
   public void runAll() {
     System.out.printf(">>>>>>>>>>>>>>>>>>%n");
-    System.out.printf("GROUP: %s%n", name);
+    System.out.printf("GROUP: %s", name);
+    if (template != null) {
+      System.out.printf(" (%s)", template.getName());
+    }
+    System.out.printf("%n");
 
     for (Benchmark benchmark : benchmarks) {
       benchmark.run();
@@ -46,11 +62,13 @@ public class BenchmarkGroup {
 
     System.out.printf("%n%nSorted by execution time:%n");
     benchmarks.stream()
-        .sorted(comparing(Benchmark::getCumulativeDuration))
+        .filter(b -> !b.isIgnored())
+        .sorted(comparing(Benchmark::getAverageDuration))
         .forEach(benchmark -> {
-          Measurement slowest = benchmark.getSlowestMeasurement();
-          System.out.printf("%6d%s / %4d%s -- %s%n", benchmark.getCumulativeDuration(), benchmark.getTimerUnit(),
-                  slowest.getDuration(), benchmark.getTimerUnit(), benchmark.getName());
+          System.out.printf("AVG: %.3fms (%10s total) -- %s%n", 
+              benchmark.toMs(benchmark.getAverageDuration()),
+              formatDurationWords(round(benchmark.toMs(benchmark.getCumulativeDuration())), true, true), 
+              benchmark.getName());
         });
 
     System.out.printf(">>>>>>>>>>>>>>>>>>%n%n");

--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/CachingRandomJCasProvider.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/CachingRandomJCasProvider.java
@@ -44,7 +44,7 @@ public class CachingRandomJCasProvider {
         throw new RuntimeException(e);
       }
 
-      initRandomCas(cachedJCas.getCas(), size, RANDOM_SEED);
+      initRandomCas(cachedJCas.getCas(), 10, size, 30, 1000, RANDOM_SEED);
       cache.put(size, cachedJCas);
     }
 

--- a/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/CasInitializationUtils.java
+++ b/uimafit-benchmark/src/main/java/org/apache/uima/fit/benchmark/CasInitializationUtils.java
@@ -35,8 +35,8 @@ public final class CasInitializationUtils
         // No instances
     }
 
-    public static void initRandomCas(CAS cas, int size, long seed)
-    {
+    public static void initRandomCas(CAS cas, int typeCount, int annotationCount, int maxAnnotationLength,
+        int approxDocLength, long seed) {
         cas.reset();
         Random rnd = new Random(seed);
         List<Type> types = new ArrayList<Type>();
@@ -44,16 +44,16 @@ public final class CasInitializationUtils
         types.add(cas.getTypeSystem().getType(Sentence.class.getName()));
 
         // Shuffle the types
-        for (int n = 0; n < 10; n++) {
+        for (int n = 0; n < typeCount; n++) {
             Type t = types.remove(rnd.nextInt(types.size()));
             types.add(t);
         }
 
         // Randomly generate annotations
-        for (int n = 0; n < size; n++) {
+        for (int n = 0; n < annotationCount; n++) {
             for (Type t : types) {
-                int begin = rnd.nextInt(100);
-                int end = begin + rnd.nextInt(30);
+                int begin = rnd.nextInt(approxDocLength);
+                int end = begin + rnd.nextInt(maxAnnotationLength);
                 cas.addFsToIndexes(cas.createAnnotation(t, begin, end));
             }
         }

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/FSUtilBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/FSUtilBenchmark.java
@@ -40,7 +40,7 @@ public class FSUtilBenchmark {
 	@Test
   public void benchmarkSetFeature() {
     Benchmark template = new Benchmark("TEMPLATE")
-      .timer(System::nanoTime)
+      .timer(System::nanoTime, t -> t / 1000)
       .repeat(1_000_000);
 
     new Benchmark("set feature string JCas", template)

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/JCasFactoryBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/JCasFactoryBenchmark.java
@@ -29,7 +29,6 @@ public class JCasFactoryBenchmark
   @Test
   public void benchmarkCreateTypeSystemDescription() throws Exception {
     Benchmark template = new Benchmark("TEMPLATE")
-      .timer(System::currentTimeMillis)
       .repeat(1000);
     
     new Benchmark("createTypeSystemDescription", template)
@@ -40,7 +39,6 @@ public class JCasFactoryBenchmark
   @Test
   public void benchmarkCreateJCas() throws Exception {
     Benchmark template = new Benchmark("TEMPLATE")
-      .timer(System::currentTimeMillis)
       .repeat(1000);
     
     TypeSystemDescription tsd = createTypeSystemDescription();

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -154,6 +154,21 @@ public class SelectBenchmark {
                         .filter(t -> coveredBy(t, s))
                         .forEach(t -> {}));
             }))
+        .add(new Benchmark("JCAS.select(Token.class).coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().select(Token.class).coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().getAnnotationIndex(Token.class).select().coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
+        .add(new Benchmark("selectCovered(JCAS, Token.class, s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        selectCovered(casProvider.get(), Token.class, s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
         .runAll();
   }
   

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -46,6 +46,8 @@ public class SelectBenchmark {
 
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(1_000)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -75,6 +77,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -111,6 +115,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -157,6 +163,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
@@ -223,6 +231,8 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
+        .timer(Benchmark::user)
+        .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -46,7 +46,7 @@ public class SelectBenchmark {
 
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(1_000)
         .magnitude(10)
@@ -79,7 +79,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
@@ -117,7 +117,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
@@ -180,7 +180,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)
@@ -248,7 +248,7 @@ public class SelectBenchmark {
     
     Benchmark template = new Benchmark("TEMPLATE")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::user)
+        .timer(Benchmark::userTime)
         .timerUnit("ns")
         .repeat(25)
         .magnitude(10)

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -68,6 +68,8 @@ public class SelectBenchmark {
             .measure(() -> JCasUtil.select(casProvider.get(), Token.class).forEach(x -> {})))
         .add(new Benchmark("JCAS.select(Token.class).forEach(x -> {})", template)
             .measure(() -> casProvider.get().select(Token.class).forEach(x -> {})))
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().forEach(x -> {})", template)
+            .measure(() -> casProvider.get().getAnnotationIndex(Token.class).select().forEach(x -> {})))
         .runAll();
   }
 
@@ -285,6 +287,16 @@ public class SelectBenchmark {
                         .filter(t -> colocated(t, s))
                         .forEach(t -> {}));
             }))
-        .runAll();  
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().getAnnotationIndex(Token.class).select().at(s).forEach(t -> {}));
+            }))
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+            .measure(() -> {
+                select(casProvider.get(), Sentence.class).forEach(s ->
+                        casProvider.get().getAnnotationIndex(Token.class).select().at(s.getBegin(), s.getEnd()).forEach(t -> {}));
+            }))
+        .runAll();
   }
 }

--- a/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
+++ b/uimafit-benchmark/src/test/java/org/apache/uima/fit/benchmark/SelectBenchmark.java
@@ -34,74 +34,84 @@ import org.apache.uima.fit.type.Token;
 import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.cas.TOP;
+import org.junit.Before;
 import org.junit.Test;
 
 public class SelectBenchmark {
   private static final String TYPE_NAME_TOKEN = "org.apache.uima.fit.type.Token";
   private static final String TYPE_NAME_SENTENCE = "org.apache.uima.fit.type.Sentence";
   
-  @Test
-  public void benchmarkSelect() {
-    CachingRandomJCasProvider casProvider = new CachingRandomJCasProvider();
-
-    Benchmark template = new Benchmark("TEMPLATE")
+  private Benchmark templateForFastOperations;
+  private Benchmark templateForNormalOperations;
+  private Benchmark warmupTask;
+  private CachingRandomJCasProvider casProvider;
+  
+  @Before
+  public void setup() {
+    casProvider = new CachingRandomJCasProvider();
+    warmupTask = new Benchmark("WARM-UP")
         .initialize(casProvider::prepare)
-        .timer(Benchmark::userTime)
-        .timerUnit("ns")
+        .repeat(100)
+        .magnitude(10)
+        .magnitudeIncrement(count -> count * 10)
+        .incrementTimes(5)
+        .ignore(true)
+        .measure(() -> casProvider.get().select().forEach(t -> {}));
+    templateForFastOperations = new Benchmark("FAST TEMPLATE")
+        .initialize(casProvider::prepare)
+        .timer(Benchmark::userTime, t -> t / 1_000_000)
         .repeat(1_000)
         .magnitude(10)
         .magnitudeIncrement(count -> count * 10)
         .incrementTimes(5);
-    
-    new BenchmarkGroup("select")
-        .add(new Benchmark("WARM-UP", template)
-            .measure(() -> casProvider.get().select().forEach(t -> {})))
-        .add(new Benchmark("JCasUtil.selectAll(JCAS).forEach(x -> {})", template)
+    templateForNormalOperations = new Benchmark("NORMAL TEMPLATE")
+        .initialize(casProvider::prepare)
+        .timer(Benchmark::userTime, t -> t / 1_000_000)
+        .repeat(10_000)
+        .magnitude(10)
+        .magnitudeIncrement(count -> count * 10)
+        .incrementTimes(4);
+  }
+
+  
+  @Test
+  public void benchmarkSelect() {
+    new BenchmarkGroup("select", templateForFastOperations)
+        .addIgnoringTemplate(warmupTask)
+        .add(new Benchmark("JCasUtil.selectAll(JCAS).forEach(x -> {})")
             .measure(() -> JCasUtil.selectAll(casProvider.get()).forEach(x -> {})))
-        .add(new Benchmark("JCAS.select().forEach(x -> {})", template)
+        .add(new Benchmark("JCAS.select().forEach(x -> {})")
             .measure(() -> casProvider.get().select().forEach(x -> {})))
-        .add(new Benchmark("JCasUtil.select(JCAS, TOP.class).forEach(x -> {})", template)
+        .add(new Benchmark("JCasUtil.select(JCAS, TOP.class).forEach(x -> {})")
             .measure(() -> JCasUtil.select(casProvider.get(), TOP.class).forEach(x -> {})))
-        .add(new Benchmark("JCAS.select(TOP.class).forEach(x -> {})", template)
+        .add(new Benchmark("JCAS.select(TOP.class).forEach(x -> {})")
             .measure(() -> casProvider.get().select(TOP.class).forEach(x -> {})))
-        .add(new Benchmark("JCasUtil.select(JCAS, Token.class).forEach(x -> {})", template)
+        .add(new Benchmark("JCasUtil.select(JCAS, Token.class).forEach(x -> {})")
             .measure(() -> JCasUtil.select(casProvider.get(), Token.class).forEach(x -> {})))
-        .add(new Benchmark("JCAS.select(Token.class).forEach(x -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).forEach(x -> {})")
             .measure(() -> casProvider.get().select(Token.class).forEach(x -> {})))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().forEach(x -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().forEach(x -> {})")
             .measure(() -> casProvider.get().getAnnotationIndex(Token.class).select().forEach(x -> {})))
         .runAll();
   }
 
   @Test
   public void benchmarkSelectOverlapping() {
-    CachingRandomJCasProvider casProvider = new CachingRandomJCasProvider();
-    
-    Benchmark template = new Benchmark("TEMPLATE")
-        .initialize(casProvider::prepare)
-        .timer(Benchmark::userTime)
-        .timerUnit("ns")
-        .repeat(25)
-        .magnitude(10)
-        .magnitudeIncrement(count -> count * 10)
-        .incrementTimes(3);
-    
-    new BenchmarkGroup("select overlapping")
-        .add(new Benchmark("WARM-UP", template)
-            .measure(() -> casProvider.get().select().forEach(t -> {})))
-        .add(new Benchmark("selectOverlapping(JCAS, Token.class, s).forEach(t -> {})", template)
+    new BenchmarkGroup("select overlapping", templateForNormalOperations)
+        .addIgnoringTemplate(warmupTask)
+        .add(new Benchmark("selectOverlapping(JCAS, Token.class, s).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     selectOverlapping(Token.class, s).forEach(t -> {}));
             }))
-        .add(new Benchmark("CAS.select(Token.class).filter(t -> overlapping(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("CAS.select(Token.class).filter(t -> overlapping(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class)
                         .filter(t -> overlapping(t, s))
                         .forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> overlapping(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> overlapping(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().getAnnotationIndex(Token.class).stream()
@@ -113,60 +123,48 @@ public class SelectBenchmark {
   
   @Test
   public void benchmarkSelectCoveredBy() {
-    CachingRandomJCasProvider casProvider = new CachingRandomJCasProvider();
-    
-    Benchmark template = new Benchmark("TEMPLATE")
-        .initialize(casProvider::prepare)
-        .timer(Benchmark::userTime)
-        .timerUnit("ns")
-        .repeat(25)
-        .magnitude(10)
-        .magnitudeIncrement(count -> count * 10)
-        .incrementTimes(3);
-    
-    new BenchmarkGroup("select covered by")
-        .add(new Benchmark("WARM-UP", template)
-            .measure(() -> casProvider.get().select().forEach(t -> {})))
-        .add(new Benchmark("selectCovered(Token.class, s).forEach(t -> {})", template)
+    new BenchmarkGroup("select covered by", templateForNormalOperations)
+        .addIgnoringTemplate(warmupTask)
+        .add(new Benchmark("selectCovered(Token.class, s).forEach(t -> {})")
             .measure(() -> {
               select(casProvider.get(), Sentence.class).forEach(s -> 
                     selectCovered(Token.class, s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).coveredBy(s).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).coveredBy(s).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class).coveredBy(s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().coveredBy(s).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().coveredBy(s).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().getAnnotationIndex(Token.class).select().coveredBy(s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).filter(t -> coveredBy(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).filter(t -> coveredBy(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class)
                         .filter(t -> coveredBy(t, s))
                         .forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> coveredBy(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> coveredBy(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().getAnnotationIndex(Token.class).stream()
                         .filter(t -> coveredBy(t, s))
                         .forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s ->
                         casProvider.get().select(Token.class).coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s ->
                         casProvider.get().getAnnotationIndex(Token.class).select().coveredBy(s.getBegin(), s.getEnd()).forEach(t -> {}));
             }))
-        .add(new Benchmark("selectCovered(JCAS, Token.class, s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+        .add(new Benchmark("selectCovered(JCAS, Token.class, s.getBegin(), s.getEnd()).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s ->
                         selectCovered(casProvider.get(), Token.class, s.getBegin(), s.getEnd()).forEach(t -> {}));
@@ -176,55 +174,43 @@ public class SelectBenchmark {
   
   @Test
   public void benchmarkSelectCovering() {
-    CachingRandomJCasProvider casProvider = new CachingRandomJCasProvider();
-    
-    Benchmark template = new Benchmark("TEMPLATE")
-        .initialize(casProvider::prepare)
-        .timer(Benchmark::userTime)
-        .timerUnit("ns")
-        .repeat(25)
-        .magnitude(10)
-        .magnitudeIncrement(count -> count * 10)
-        .incrementTimes(3);
-    
-    new BenchmarkGroup("select covering")
-        .add(new Benchmark("WARM-UP", template)
-            .measure(() -> casProvider.get().select().forEach(t -> {})))
-        .add(new Benchmark("JCasUtil.selectCovering(Token.class, s).forEach(t -> {})", template)
+    new BenchmarkGroup("select covering", templateForNormalOperations)
+        .addIgnoringTemplate(warmupTask)
+        .add(new Benchmark("JCasUtil.selectCovering(Token.class, s).forEach(t -> {})")
             .measure(() -> {
               select(casProvider.get(), Sentence.class).forEach(s -> 
                     JCasUtil.selectCovering(Token.class, s).forEach(t -> {}));
             }))
-        .add(new Benchmark("CasUtil.selectCovering(tokenType, s).forEach(t -> {})", template)
+        .add(new Benchmark("CasUtil.selectCovering(tokenType, s).forEach(t -> {})")
             .measure(() -> {
                 CAS cas = casProvider.get().getCas();
                 select(cas, getType(cas, TYPE_NAME_SENTENCE)).forEach(s -> 
                     CasUtil.selectCovering(getType(cas, TYPE_NAME_TOKEN), s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).covering(s).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).covering(s).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class).covering(s).forEach(t -> {}));
             }))
-        .add(new Benchmark("CAS.getAnnotationIndex(getType(cas, TYPE_NAME_TOKEN)).select().covering(s).forEach(t -> {})", template)
+        .add(new Benchmark("CAS.getAnnotationIndex(getType(cas, TYPE_NAME_TOKEN)).select().covering(s).forEach(t -> {})")
             .measure(() -> {
                 CAS cas = casProvider.get().getCas();
                 select(cas, getType(cas, TYPE_NAME_SENTENCE)).forEach(s -> 
                     casProvider.get().getAnnotationIndex(getType(cas, TYPE_NAME_TOKEN)).select().covering(s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().covering(s).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().covering(s).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().getAnnotationIndex(Token.class).select().covering(s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).filter(t -> covering(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).filter(t -> covering(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class)
                         .filter(t -> covering(t, s))
                         .forEach(t -> {}));
             }))
-        .add(new Benchmark("CAS.getAnnotationIndex(getType(cas, TYPE_NAME_TOKEN)).stream().filter(t -> covering(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("CAS.getAnnotationIndex(getType(cas, TYPE_NAME_TOKEN)).stream().filter(t -> covering(t, s)).forEach(t -> {})")
             .measure(() -> {
                 CAS cas = casProvider.get().getCas();
                 select(cas, getType(cas, TYPE_NAME_SENTENCE)).forEach(s -> 
@@ -232,7 +218,7 @@ public class SelectBenchmark {
                         .filter(t -> covering(t, s))
                         .forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> covering(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> covering(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().getAnnotationIndex(Token.class).stream()
@@ -244,55 +230,43 @@ public class SelectBenchmark {
   
   @Test
   public void benchmarkSelectAt() {
-    CachingRandomJCasProvider casProvider = new CachingRandomJCasProvider();
-    
-    Benchmark template = new Benchmark("TEMPLATE")
-        .initialize(casProvider::prepare)
-        .timer(Benchmark::userTime)
-        .timerUnit("ns")
-        .repeat(25)
-        .magnitude(10)
-        .magnitudeIncrement(count -> count * 10)
-        .incrementTimes(3);
-    
-    new BenchmarkGroup("select at")
-        .add(new Benchmark("WARM-UP", template)
-            .measure(() -> casProvider.get().select().forEach(t -> {})))
-        .add(new Benchmark("JCasUtil.selectAt(CAS, Token.class, s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+    new BenchmarkGroup("select at", templateForNormalOperations)
+        .addIgnoringTemplate(warmupTask)
+        .add(new Benchmark("JCasUtil.selectAt(CAS, Token.class, s.getBegin(), s.getEnd()).forEach(t -> {})")
             .measure(() -> {
               select(casProvider.get(), Sentence.class).forEach(s -> 
                     JCasUtil.selectAt(casProvider.get(), Token.class, s.getBegin(), s.getEnd()).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).at(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).at(s.getBegin(), s.getEnd()).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class).at(s.getBegin(), s.getEnd()).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).at(s).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).at(s).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class).at(s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.select(Token.class).filter(t -> colocated(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.select(Token.class).filter(t -> colocated(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().select(Token.class)
                         .filter(t -> colocated(t, s))
                         .forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> colocated(t, s)).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).stream().filter(t -> colocated(t, s)).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s -> 
                     casProvider.get().getAnnotationIndex(Token.class).stream()
                         .filter(t -> colocated(t, s))
                         .forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s ->
                         casProvider.get().getAnnotationIndex(Token.class).select().at(s).forEach(t -> {}));
             }))
-        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s.getBegin(), s.getEnd()).forEach(t -> {})", template)
+        .add(new Benchmark("JCAS.getAnnotationIndex(Token.class).select().at(s.getBegin(), s.getEnd()).forEach(t -> {})")
             .measure(() -> {
                 select(casProvider.get(), Sentence.class).forEach(s ->
                         casProvider.get().getAnnotationIndex(Token.class).select().at(s.getBegin(), s.getEnd()).forEach(t -> {}));


### PR DESCRIPTION
JIRA Ticket: https://issues.apache.org/jira/browse/UIMA-6291

- Changed new timer names to include the postfix time, so that it is more clear that it is a time value.
- Added select and selectAt benchmarks using getAnnotationIndex approach.
- Added more selectCovered benchmarks with s.getBegin() and s.getEnd().
- Added support for nanoseconds CPU time support in Benchmark and changed SelectBenchmark to use user time.
