### PR TITLE
[UIMA-6331] uimaFIT 3.2.0 release

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 
-      Apache uimaFIT (TM) v3.1.0
+      Apache uimaFIT (TM) v3.2.0
       --------------------------
 
 
@@ -37,36 +37,45 @@ following list highlights some of the features uimaFIT provides:
      SimplePipeline.runPipeline(reader, ae1, ..., aeN, consumer1, ... consumerN)
 
 
-What's New in 3.1.0
+What's New in 3.2.0
 -------------------
 
-uimaFIT 3.1.0 is a minor feature and bugfix release. On supported platforms, it serves mostly as 
-a drop-in replacement for previous uimaFIT 3.x versions. However, due to a clash in method
-signatures, you may notice incompatible changes in the methods provided ExternalResourceFactory.
-For details, please refer to the migration section in the documentation.
+uimaFIT 3.2.0 is a feature and bugfix release. On supported platforms, it serves mostly as 
+a drop-in replacement for previous uimaFIT 3.x versions. However, the behavior of the various
+select methods was slightly adapted in edge cases to align with the update behavior of the UIMA Java
+SDK SelectFS API.  For details, please refer to the migration section in the documentation in the
+Apache UIMA Java SDK 3.2.0.
 
 Notable changes in this release include:
 
- * Added support for PEARs in AnalysisEngineFactory
- * Added ExternalResourceFactory.createResource(...) methods for instantiating resources
- * Added support for Charset-typed parameters in components
- * Added ability to set number of threads in CpePipeline.runPipeline(...)
- * Fixed issue with non-XML 1.0 characters in parameter values when running CPEs
- * Fixed JCasIterable.iterator() destroying the ResourceManager before it is even used
- * Fixed issue causing component parameters to be used when initializing resources
- * Fixed CollectionReaderFactory.createReaderDescription(...) not discovering type prios and indexes
- * Fixed clashing method signatures of ExternalResourceFactory.bindResource(...)
- * Upgraded to UIMA 3.1.1
- * Upgraded to Spring 4.3.26
+#### New Features and improvements
+
+* [UIMA-6242] - uimaFIT Maven plugin should fail on error by default
+* [UIMA-6263] - CAS validation support
+* [UIMA-6270] - Add selectOverlapping to (J)CasUtil
+* [UIMA-6311] - Add generated resources output folder as resource folder
+* [UIMA-6312] - Better PEAR parameter support
+* [UIMA-6232] - Reduce overhead of createTypeSystemDescription() and friends
+
+#### Bugs fixed
+
+* [UIMA-6226] - uimaFIT maven plugin "generate" fails to import type systems from dependencies
+* [UIMA-6240] - Failure to resolve type system imports when generating descriptors
+* [UIMA-6275] - InitializableFactory is not smart enough to find a suitable classloader
+* [UIMA-6286] - select following finds zero-width annotation at reference end position
+* [UIMA-6292] - selectCovering is slow
+* [UIMA-6294] - SelectFS.at(annotation) does not return the correct result
+* [UIMA-6314] - Align preceding/following with predicate in UIMA core
+
  
 A full list of issues addressed in this release can be found on the Apache issue tracker:
 
-  https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310570&version=12343882
+  https://issues.apache.org/jira/issues/?jql=project%20%3D%20UIMA%20AND%20fixVersion%20%3D%203.2.0uimaFIT
 
 Supported Platforms
 -------------------
 
-uimaFIT requires Java 1.8 or higher, UIMA 3.1.1 or higher, and the Spring Framework 4.3.26 or higher.
+uimaFIT requires Java 1.8 or higher, UIMA 3.2.0 or higher, and the Spring Framework 4.3.30 or higher.
 
 
 Availability
@@ -83,7 +92,7 @@ add uimaFIT as a dependency to your pom.xml file with the following:
   <dependency>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-core</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
   </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <relativePath>uimafit-parent</relativePath>
   </parent>
   <properties>
-    <jiraVersion>3.1.0uimaFIT</jiraVersion>
+    <jiraVersion>3.2.0uimaFIT</jiraVersion>
   </properties>
   <scm>
     <connection>scm:git:git://github.com/apache/uima-uimafit</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>uimafit-parent</relativePath>
   </parent>
   <properties>
@@ -38,7 +38,7 @@
     <connection>scm:git:git://github.com/apache/uima-uimafit</connection>
     <developerConnection>scm:git:git@github.com:apache/uima-uimafit.git</developerConnection>
     <url>https://github.com/apache/uima-uimafit</url>
-    <tag>uimafit-3.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
   <licenses>
     <license>
@@ -51,22 +51,22 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-cpe</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-junit</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-assertj</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>uimafit-parent</relativePath>
   </parent>
   <properties>
@@ -38,7 +38,7 @@
     <connection>scm:git:git://github.com/apache/uima-uimafit</connection>
     <developerConnection>scm:git:git@github.com:apache/uima-uimafit.git</developerConnection>
     <url>https://github.com/apache/uima-uimafit</url>
-    <tag>HEAD</tag>
+    <tag>uimafit-3.2.0</tag>
   </scm>
   <licenses>
     <license>
@@ -51,22 +51,22 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-cpe</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-junit</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-assertj</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/uimafit-assertj/pom.xml
+++ b/uimafit-assertj/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-assertj</artifactId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-assertj/pom.xml
+++ b/uimafit-assertj/pom.xml
@@ -17,14 +17,12 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-assertj</artifactId>
@@ -33,7 +31,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-benchmark/pom.xml
+++ b/uimafit-benchmark/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <properties>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-benchmark/pom.xml
+++ b/uimafit-benchmark/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <properties>
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <dependencies>

--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <dependencies>

--- a/uimafit-cpe/pom.xml
+++ b/uimafit-cpe/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-cpe</artifactId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-cpe/pom.xml
+++ b/uimafit-cpe/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-cpe</artifactId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-doc/pom.xml
+++ b/uimafit-doc/pom.xml
@@ -17,14 +17,12 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-doc</artifactId>

--- a/uimafit-doc/pom.xml
+++ b/uimafit-doc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-doc</artifactId>

--- a/uimafit-examples/pom.xml
+++ b/uimafit-examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-examples/pom.xml
+++ b/uimafit-examples/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-junit/pom.xml
+++ b/uimafit-junit/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-junit</artifactId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-junit/pom.xml
+++ b/uimafit-junit/pom.xml
@@ -17,14 +17,12 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-junit</artifactId>
@@ -33,7 +31,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/uimafit-maven-plugin/pom.xml
+++ b/uimafit-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-maven-plugin</artifactId>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>

--- a/uimafit-maven-plugin/pom.xml
+++ b/uimafit-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <artifactId>uimafit-maven-plugin</artifactId>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -42,7 +42,6 @@
   <repositories>
     <!--
       - For UIMA/uimaFIT SNAPSHOTs
-    -->
     <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshot Repository</name>
@@ -51,11 +50,11 @@
         <enabled>false</enabled>
       </releases>
     </repository>
+    -->
   </repositories>
   <pluginRepositories>
     <!--
       - For UIMA/uimaFIT SNAPSHOTs
-      -->
     <pluginRepository>
       <id>apache.snapshots.plugins</id>
       <name>Apache Snapshot Repository - Maven plugins</name>
@@ -70,6 +69,7 @@
         <updatePolicy>never</updatePolicy>
       </snapshots>
     </pluginRepository>
+      -->
   </pluginRepositories>
 
   <dependencies>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -26,7 +26,7 @@
     <version>14</version>
   </parent>
   <artifactId>uimafit-parent</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>3.2.0</version>
   <packaging>pom</packaging>
   <name>Apache UIMA uimaFIT - Parent</name>
   <url>${uimaWebsiteUrl}</url>
@@ -381,4 +381,8 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <scm>
+    <tag>uimafit-3.2.0</tag>
+  </scm>
 </project>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -26,7 +26,7 @@
     <version>14</version>
   </parent>
   <artifactId>uimafit-parent</artifactId>
-  <version>3.2.0</version>
+  <version>3.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache UIMA uimaFIT - Parent</name>
   <url>${uimaWebsiteUrl}</url>
@@ -383,6 +383,9 @@
   </build>
 
   <scm>
-    <tag>uimafit-3.2.0</tag>
+    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/apache/uima-uimafit</connection>
+    <developerConnection>scm:git:git@github.com:apache/uima-uimafit.git</developerConnection>
+    <url>https://github.com/apache/uima-uimafit</url>
   </scm>
 </project>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
     <relativePath />
-    <version>14-SNAPSHOT</version>
+    <version>14</version>
   </parent>
   <artifactId>uimafit-parent</artifactId>
   <version>3.2.0-SNAPSHOT</version>
@@ -55,7 +55,7 @@
   <pluginRepositories>
     <!--
       - For UIMA/uimaFIT SNAPSHOTs
-    -->
+      -->
     <pluginRepository>
       <id>apache.snapshots.plugins</id>
       <name>Apache Snapshot Repository - Maven plugins</name>
@@ -155,16 +155,6 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
         <version>${spring.version}</version>
-        <!--
-          - This is excluded in the assembly and not here to avoid unwanted side-effects
-          - on users' projects.
-          <exclusions>
-          <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-aop</artifactId>
-          </exclusion>
-          </exclusions>
-        -->
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -298,7 +288,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.8.1</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>
@@ -345,42 +335,6 @@
                     <versionRange>[1.4,)</versionRange>
                     <goals>
                       <goal>execute</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <!-- *********************************************** -->
-                <!-- The Maven Dev Connector for Eclipse m2e is no   -->
-                <!-- longer maintained. We copy the relevant part    --> 
-                <!-- of the lifecycle mapping for the                -->
-                <!-- maven-plugin-plugin here.                       -->
-                <!--                                                 -->
-                <!-- See https://github.com/ifedorenko/com.ifedorenko.m2e.mavendev/blob/master/com.ifedorenko.m2e.mavendev/lifecycle-mapping-metadata.xml -->
-                <!-- *********************************************** -->
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-plugin-plugin</artifactId>
-                    <versionRange>[3.5.2,)</versionRange>
-                    <goals>
-                      <goal>descriptor</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>false</runOnIncremental>
-                    </execute>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-plugin-plugin</artifactId>
-                    <versionRange>[3.5.2,)</versionRange>
-                    <goals>
-                      <goal>helpmojo</goal>
                     </goals>
                   </pluginExecutionFilter>
                   <action>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -37,7 +37,7 @@
     <slf4j.version>1.7.26</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <api_check_oldVersion>3.0.0</api_check_oldVersion>
+    <api_check_oldVersion>3.1.0</api_check_oldVersion>
   </properties>
   <repositories>
     <!--

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -33,7 +33,7 @@
   <inceptionYear>2012</inceptionYear>
   <properties>
     <spring.version>4.3.30.RELEASE</spring.version>
-    <uima.version>3.2.0-SNAPSHOT</uima.version>
+    <uima.version>3.2.0</uima.version>
     <slf4j.version>1.7.26</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/uimafit-spring/pom.xml
+++ b/uimafit-spring/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <dependencies>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/uimafit-spring/pom.xml
+++ b/uimafit-spring/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>uimafit-parent</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <relativePath>../uimafit-parent</relativePath>
   </parent>
   <dependencies>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
- Upgrade to UIMA Parent POM 14 release version
- Remove outdated commented-out dependency on Spring AOP
- Upgrade Maven Compile Plugin to same version we have in the parent
- Remove m2e configurations already included in the parent POM

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6331
