### PR TITLE
UIMA-6351: japicmp post processing script fails with Java 16 (uimaFIT)

### DIFF
--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
     <relativePath />
-    <version>14-SNAPSHOT</version>
+    <version>14</version>
   </parent>
   <artifactId>uimafit-parent</artifactId>
   <version>2.5.1-SNAPSHOT</version>
@@ -184,6 +184,19 @@
   <build>
     <plugins>
       <plugin>
+        <!-- See: https://issues.apache.org/jira/browse/UIMA-6351 -->
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.15.3</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>2.5.14</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
@@ -232,7 +245,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.7</version>
             <type>pom</type>
           </dependency>
         </dependencies>


### PR DESCRIPTION
- Upgrade japicmp / groovy plugin/plugin dependencies for compatibility with Java 16
- Upgrade groovy-all plugin dependency for compatibility with Java 16
- Upgrade to parent POM 14 (release)

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-UIMA-6351
