### PR TITLE
[UIMA-6384] parallelism argument in CpePipeline is ignored

### DIFF
--- a/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpePipeline.java
+++ b/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpePipeline.java
@@ -102,7 +102,7 @@ public final class CpePipeline {
     CpeBuilder builder = new CpeBuilder();
     builder.setReader(readerDesc);
     builder.setAnalysisEngine(aaeDesc);
-    builder.setMaxProcessingUnitThreadCount(Runtime.getRuntime().availableProcessors() - 1);
+    builder.setMaxProcessingUnitThreadCount(parallelism);
 
     StatusCallbackListenerImpl status = new StatusCallbackListenerImpl();
     CollectionProcessingEngine engine = builder.createCpe(status);


### PR DESCRIPTION
- actually use the parallelism argument instead of ignoring it

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6384
