### PR TITLE
[UIMA-6392] Better delegate key generation

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/AggregateBuilder.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/AggregateBuilder.java
@@ -42,7 +42,8 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
  * This is an example taken from our test cases:
  * </p>
  * 
- * <pre><code>
+ * <pre>
+ * <code>
  * import static org.apache.uima.fit.factory.AnalysisEngineFactory.createPrimitiveDescription;
  * 
  * AggregateBuilder builder = new AggregateBuilder();
@@ -55,7 +56,8 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
  * builder.add(createPrimitiveDescription(Annotator3.class, typeSystemDescription),
  *     ViewNames.INITIAL_VIEW, "B");
  * AnalysisEngine aggregateEngine = builder.createAggregate();
- * </code></pre>
+ * </code>
+ * </pre>
  */
 public class AggregateBuilder {
 
@@ -114,17 +116,7 @@ public class AggregateBuilder {
    * @return the name of the component generated for the {@link AnalysisEngineDescription}
    */
   public String add(AnalysisEngineDescription aed, String... viewNames) {
-    String componentName = aed.getAnalysisEngineMetaData().getName();
-    if (componentName == null || componentName.equals("")) {
-      if (aed.isPrimitive()) {
-        componentName = aed.getAnnotatorImplementationName();
-      } else {
-        componentName = "aggregate";
-      }
-    }
-    if (componentNames.contains(componentName)) {
-      componentName = componentName + "." + (componentNames.size() + 1);
-    }
+    String componentName = AnalysisEngineFactory.generateDelegateKey(aed, componentNames.size());
     add(componentName, aed, viewNames);
     return componentName;
   }
@@ -220,8 +212,8 @@ public class AggregateBuilder {
    */
   public AnalysisEngineDescription createAggregateDescription()
           throws ResourceInitializationException {
-    return AnalysisEngineFactory.createEngineDescription(analysisEngineDescriptions,
-            componentNames, typePriorities,
-            sofaMappings.toArray(new SofaMapping[sofaMappings.size()]), flowControllerDescription);
+    return AnalysisEngineFactory.createEngineDescription(analysisEngineDescriptions, componentNames,
+            typePriorities, sofaMappings.toArray(new SofaMapping[sofaMappings.size()]),
+            flowControllerDescription);
   }
 }

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/AggregateBuilderTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/AggregateBuilderTest.java
@@ -117,9 +117,9 @@ public class AggregateBuilderTest extends ComponentTestBase {
     String componentName3 = builder.add(AnalysisEngineFactory.createEngineDescription(
             Annotator1.class, typeSystemDescription));
 
-    assertEquals("org.apache.uima.fit.factory.testAes.Annotator1", componentName1);
-    assertEquals("org.apache.uima.fit.factory.testAes.Annotator1.2", componentName2);
-    assertEquals("org.apache.uima.fit.factory.testAes.Annotator1.3", componentName3);
+    assertEquals("org.apache.uima.fit.factory.testAes.Annotator1-0", componentName1);
+    assertEquals("org.apache.uima.fit.factory.testAes.Annotator1-1", componentName2);
+    assertEquals("org.apache.uima.fit.factory.testAes.Annotator1-2", componentName3);
 
     builder.addSofaMapping(componentName1, ViewNames.PARENTHESES_VIEW, "A");
     builder.addSofaMapping(componentName2, ViewNames.PARENTHESES_VIEW, "B");

--- a/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpeBuilder.java
+++ b/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpeBuilder.java
@@ -97,8 +97,8 @@ public class CpeBuilder {
    * @throws CpeDescriptorException
    *           if there was a problem adding the reader to the CPE.
    */
-  public void setReader(CollectionReaderDescription aDesc) throws IOException, SAXException,
-          CpeDescriptorException {
+  public void setReader(CollectionReaderDescription aDesc)
+          throws IOException, SAXException, CpeDescriptorException {
     // Remove all collection readers
     cpeDesc.setAllCollectionCollectionReaders(new CpeCollectionReader[0]);
 
@@ -123,8 +123,8 @@ public class CpeBuilder {
    * @throws InvalidXMLException
    *           if import resolution failed
    */
-  public void setAnalysisEngine(AnalysisEngineDescription aDesc) throws IOException, SAXException,
-          CpeDescriptorException, InvalidXMLException {
+  public void setAnalysisEngine(AnalysisEngineDescription aDesc)
+          throws IOException, SAXException, CpeDescriptorException, InvalidXMLException {
     // Remove all CAS processors
     cpeDesc.setCpeCasProcessors(null);
 
@@ -176,8 +176,8 @@ public class CpeBuilder {
    *          A resource specifier that should we materialized.
    * @return The file containing the XML representation of the given resource.
    */
-  private static File materializeDescriptor(ResourceSpecifier resource) throws IOException,
-          SAXException {
+  private static File materializeDescriptor(ResourceSpecifier resource)
+          throws IOException, SAXException {
     File tempDesc = File.createTempFile("desc", ".xml");
     tempDesc.deleteOnExit();
 
@@ -195,7 +195,8 @@ public class CpeBuilder {
   }
 
   private static CpeIntegratedCasProcessor createProcessor(String key,
-          AnalysisEngineDescription aDesc) throws IOException, SAXException, CpeDescriptorException {
+          AnalysisEngineDescription aDesc)
+          throws IOException, SAXException, CpeDescriptorException {
     URL descUrl = materializeDescriptor(aDesc).toURI().toURL();
 
     CpeInclude cpeInclude = getResourceSpecifierFactory().createInclude();
@@ -205,6 +206,7 @@ public class CpeBuilder {
     ccd.setInclude(cpeInclude);
 
     CpeIntegratedCasProcessor proc = produceCasProcessor(key);
+    proc.setName(key);
     proc.setCpeComponentDescriptor(ccd);
     proc.setAttributeValue(CpeDefaultValues.PROCESSING_UNIT_THREAD_COUNT, 1);
     proc.setActionOnMaxError(ACTION_ON_MAX_ERROR);

--- a/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpePipeline.java
+++ b/uimafit-cpe/src/main/java/org/apache/uima/fit/cpe/CpePipeline.java
@@ -34,6 +34,8 @@ import org.apache.uima.collection.EntityProcessStatus;
 import org.apache.uima.collection.StatusCallbackListener;
 import org.apache.uima.collection.metadata.CpeDescriptorException;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.Import;
+import org.apache.uima.resource.metadata.MetaDataObject;
 import org.apache.uima.util.InvalidXMLException;
 import org.xml.sax.SAXException;
 
@@ -41,11 +43,11 @@ public final class CpePipeline {
   private CpePipeline() {
     // No instances
   }
-  
+
   /**
-   * Run the CollectionReader and AnalysisEngines as a multi-threaded pipeline. This call uses
-   * a number of threads equal to the number of available processors (as reported by Java, so 
-   * usually boiling down to cores) minus 1 - minimum of 1.
+   * Run the CollectionReader and AnalysisEngines as a multi-threaded pipeline. This call uses a
+   * number of threads equal to the number of available processors (as reported by Java, so usually
+   * boiling down to cores) minus 1 - minimum of 1.
    * 
    * @param readerDesc
    *          The CollectionReader that loads the documents into the CAS.
@@ -96,24 +98,30 @@ public final class CpePipeline {
    *           referenced from the CPE descriptor
    * @throws CpeDescriptorException
    *           if there was a problem configuring the CPE descriptor
-   * @throws ResourceInitializationException 
+   * @throws ResourceInitializationException
    *           if there was a problem initializing or running the CPE.
-   * @throws InvalidXMLException 
+   * @throws InvalidXMLException
    *           if there was a problem initializing or running the CPE.
-   * @throws AnalysisEngineProcessException 
+   * @throws AnalysisEngineProcessException
    *           if there was a problem running the CPE.
    */
   public static void runPipeline(final int parallelism,
           final CollectionReaderDescription readerDesc, final AnalysisEngineDescription... descs)
           throws SAXException, CpeDescriptorException, IOException, ResourceInitializationException,
           InvalidXMLException, AnalysisEngineProcessException {
-    // Create AAE
-    final AnalysisEngineDescription aaeDesc = createEngineDescription(descs);
+    AnalysisEngineDescription topLevelAnalysisEngine;
+
+    if (descs.length == 1 && !mayContainCasMultiplier(descs[0])) {
+      topLevelAnalysisEngine = descs[0];
+    } else {
+      topLevelAnalysisEngine = createEngineDescription(descs);
+      topLevelAnalysisEngine.getMetaData().setName("Top-level CPE Aggregate");
+    }
 
     CpeBuilder builder = new CpeBuilder();
     builder.setReader(readerDesc);
-    builder.setAnalysisEngine(aaeDesc);
-    builder.setMaxProcessingUnitThreadCount(Runtime.getRuntime().availableProcessors() - 1);
+    builder.setAnalysisEngine(topLevelAnalysisEngine);
+    builder.setMaxProcessingUnitThreadCount(parallelism);
 
     StatusCallbackListenerImpl status = new StatusCallbackListenerImpl();
     CollectionProcessingEngine engine = builder.createCpe(status);
@@ -132,6 +140,29 @@ public final class CpePipeline {
     if (status.exceptions.size() > 0) {
       throw new AnalysisEngineProcessException(status.exceptions.get(0));
     }
+  }
+  
+  private static boolean mayContainCasMultiplier(final AnalysisEngineDescription desc) {
+    if (desc.isPrimitive()) {
+      return desc.getAnalysisEngineMetaData().getOperationalProperties().isMultipleDeploymentAllowed();
+    }
+    
+    for (MetaDataObject mdo : desc.getDelegateAnalysisEngineSpecifiersWithImports().values()) {
+      if (mdo instanceof Import) {
+        // The imported delegate might be a CAS multiplier, but we cannot really tell without
+        // risking an exception. So let's just assume it does.
+        return true;
+      }
+      
+      if (mdo instanceof AnalysisEngineDescription) {
+        AnalysisEngineDescription aed = (AnalysisEngineDescription) mdo;
+        if (aed.getAnalysisEngineMetaData().getOperationalProperties().getOutputsNewCASes()) {
+          return true;
+        }
+      }
+    }
+    
+    return false;
   }
 
   private static class StatusCallbackListenerImpl implements StatusCallbackListener {


### PR DESCRIPTION
- Improve generation of delegate keys based on the metadata name field or based on whether the delegate is a primitive or aggregate
- Added unit tests for the delegate key generation
- Avoid wrapping aggregates in another aggregate in the CpePipeline to avoid unnecessary deep contexts - except if there maybe CAS multipliers involved because then they wouldn't work anymore

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6392
