### PR TITLE
[UIMA-6385] Potential resource key clash in environments with multiple classloaders

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/ExternalResourceFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.uima.fit.factory;
 
+import static java.lang.System.identityHashCode;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.apache.uima.UIMAFramework.getResourceSpecifierFactory;
@@ -1303,7 +1304,7 @@ public final class ExternalResourceFactory {
   }
 
   static String uniqueResourceKey(String aKey) {
-    return aKey + '-' + DISAMBIGUATOR.getAndIncrement();
+    return aKey + '-' + identityHashCode(DISAMBIGUATOR) + '-' + DISAMBIGUATOR.getAndIncrement();
   }
 
   /**


### PR DESCRIPTION
- Disambiguate the static disambiguator via its identity hash code (which should by unique for the entire JVM when there are multiple static disambiguators in different classloaders for some reason)

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6385
