### PR TITLE
[UIMA-6396] uimaFIT maven plugin mixes up test and compile scopes

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
@@ -120,15 +120,17 @@ public final class TypeSystemDescriptionFactory {
             XMLInputSource xmlInputType1 = new XMLInputSource(location);
             tsdList.add(getXMLParser().parseTypeSystemDescription(xmlInputType1));
             LogFactory.getLog(TypeSystemDescription.class)
-            .debug("Detected type system at [" + location + "]");
+              .debug("Detected type system at [" + location + "]");
           } catch (IOException e) {
             throw new ResourceInitializationException(e);
           } catch (InvalidXMLException e) {
             LogFactory.getLog(TypeSystemDescription.class)
-            .warn("[" + location + "] is not a type file. Ignoring.", e);
+              .warn("[" + location + "] is not a type file. Ignoring.", e);
           }
         }
 
+        LogFactory.getLog(TypeSystemDescription.class)
+          .trace("Merging type systems and resolving imports...");
         ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
         tsd = mergeTypeSystems(tsdList, resMgr);
         typeDescriptorByClassloader.put(cl, tsd);

--- a/uimafit-core/src/main/java/org/apache/uima/fit/internal/ResourceManagerFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/internal/ResourceManagerFactory.java
@@ -20,6 +20,7 @@ package org.apache.uima.fit.internal;
 
 import java.net.MalformedURLException;
 
+import org.apache.commons.logging.LogFactory;
 import org.apache.uima.UIMAFramework;
 import org.apache.uima.UimaContext;
 import org.apache.uima.UimaContextAdmin;
@@ -75,6 +76,8 @@ public class ResourceManagerFactory {
           // handle switching across more than one classloader.
           // This can be done since UIMA 2.9.0 and starts being handled in uimaFIT 2.3.0
           // See https://issues.apache.org/jira/browse/UIMA-5056
+          LogFactory.getLog(ResourceManagerFactory.class)
+            .trace("Using resource manager from active UIMA context");
           return ((UimaContextAdmin) activeContext).getResourceManager();
         }
 
@@ -83,10 +86,13 @@ public class ResourceManagerFactory {
         // This was the default behavior until uimaFIT 2.2.0.
         ResourceManager resMgr;
         if (Thread.currentThread().getContextClassLoader() != null) {
-          // If the context classloader is set, then we want the resource manager to fallb
-          // back to it. However, it may not reliably do that that unless we explictly pass
+          // If the context classloader is set, then we want the resource manager to fall
+          // back to it. However, it may not reliably do that that unless we explicitly pass
           // null here. See. UIMA-6239.
+          LogFactory.getLog(ResourceManagerFactory.class)
+            .trace("Detected thread context classloader: preparing resource manager to use it");
           resMgr = new ResourceManager_impl(null);
+          resMgr.setExtensionClassPath(ClassLoaderUtils.findClassloader(), "", true);
         }
         else {
           resMgr = UIMAFramework.newDefaultResourceManager();
@@ -102,6 +108,9 @@ public class ResourceManagerFactory {
                 (maj == 2 && (min < 10 || (min == 10 && rev < 3))) || // version < 2.10.3
                 (maj == 3 && ((min == 0 && rev < 1)));                // version < 3.0.1
         if (uimaCoreIgnoresContextClassloader) {
+          LogFactory.getLog(ResourceManagerFactory.class)
+            .trace("Detected UIMA version " + maj + "." + min + "." + rev + 
+                    " which ignores the thread context classloader, setting it explicitly");
           resMgr.setExtensionClassPath(ClassLoaderUtils.findClassloader(), "", true);
         }
 

--- a/uimafit-maven-plugin/pom.xml
+++ b/uimafit-maven-plugin/pom.xml
@@ -131,7 +131,7 @@
           <settingsFile>src/it/settings.xml</settingsFile>
           <goals>
             <goal>clean</goal>
-            <goal>test-compile</goal>
+            <goal>package</goal>
           </goals>
         </configuration>
         <executions>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/compile-artifact/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/compile-artifact/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	~ Licensed to the Apache Software Foundation (ASF) under one
+	~ or more contributor license agreements. See the NOTICE file
+	~ distributed with this work for additional information
+	~ regarding copyright ownership. The ASF licenses this file
+	~ to you under the Apache License, Version 2.0 (the
+	~ "License"); you may not use this file except in compliance
+	~ with the License. You may obtain a copy of the License at
+	~
+	~ http://www.apache.org/licenses/LICENSE-2.0
+	~
+	~ Unless required by applicable law or agreed to in writing,
+	~ software distributed under the License is distributed on an
+	~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	~ KIND, either express or implied. See the License for the
+	~ specific language governing permissions and limitations
+	~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.uima.fit.maven.it</groupId>
+    <artifactId>default</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>compile-artifact</artifactId>
+</project>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/compile-artifact/src/main/resources/META-INF/org.apache.uima.fit/types.txt
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/compile-artifact/src/main/resources/META-INF/org.apache.uima.fit/types.txt
@@ -1,0 +1,1 @@
+classpath*:org/apache/uima/fit/type/compileartifact/types.xml

--- a/uimafit-maven-plugin/src/it/compile-test-scope/compile-artifact/src/main/resources/org/apache/uima/fit/type/compileartifact/types.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/compile-artifact/src/main/resources/org/apache/uima/fit/type/compileartifact/types.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements. See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership. The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied. See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+  <name>Compile Types</name>
+  <description></description>
+  <version>1.0</version>
+  <vendor/>
+  <types>
+    <typeDescription>
+      <name>org.apache.uima.fit.type.CompileType</name>
+      <description/>
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+    </typeDescription>
+  </types>
+</typeSystemDescription>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact-plus-test-scope/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact-plus-test-scope/pom.xml
@@ -62,7 +62,7 @@
         <executions>
           <execution>
             <id>default</id>
-            <phase>process-classes</phase>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>enhance</goal>
               <goal>generate</goal>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact-plus-test-scope/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact-plus-test-scope/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	~ Licensed to the Apache Software Foundation (ASF) under one
+	~ or more contributor license agreements. See the NOTICE file
+	~ distributed with this work for additional information
+	~ regarding copyright ownership. The ASF licenses this file
+	~ to you under the Apache License, Version 2.0 (the
+	~ "License"); you may not use this file except in compliance
+	~ with the License. You may obtain a copy of the License at
+	~
+	~ http://www.apache.org/licenses/LICENSE-2.0
+	~
+	~ Unless required by applicable law or agreed to in writing,
+	~ software distributed under the License is distributed on an
+	~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	~ KIND, either express or implied. See the License for the
+	~ specific language governing permissions and limitations
+	~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.uima.fit.maven.it</groupId>
+    <artifactId>default</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>main-artifact-plus-test-scope</artifactId>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.uima.fit.maven.it</groupId>
+      <artifactId>compile-artifact</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima.fit.maven.it</groupId>
+      <artifactId>test-artifact</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+      <version>@pom.version@</version>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.uima</groupId>
+        <artifactId>uimafit-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <componentVendor>Apache UIMA</componentVendor>
+          <componentCopyright>Copyright by the respective authors.</componentCopyright>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>enhance</goal>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <includeScope>test</includeScope>
+              <addTypeSystemDescriptions>EMBEDDED</addTypeSystemDescriptions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact-plus-test-scope/src/main/java/TestAnnotator.java
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact-plus-test-scope/src/main/java/TestAnnotator.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import org.apache.uima.analysis_component.JCasAnnotator_ImplBase;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.jcas.JCas;
+
+/**
+ * Test annotator.
+ */
+public class TestAnnotator extends JCasAnnotator_ImplBase {
+
+  @Override
+  public void process(JCas aJCas) throws AnalysisEngineProcessException {
+    // Nothing to do
+  }
+}

--- a/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	~ Licensed to the Apache Software Foundation (ASF) under one
+	~ or more contributor license agreements. See the NOTICE file
+	~ distributed with this work for additional information
+	~ regarding copyright ownership. The ASF licenses this file
+	~ to you under the Apache License, Version 2.0 (the
+	~ "License"); you may not use this file except in compliance
+	~ with the License. You may obtain a copy of the License at
+	~
+	~ http://www.apache.org/licenses/LICENSE-2.0
+	~
+	~ Unless required by applicable law or agreed to in writing,
+	~ software distributed under the License is distributed on an
+	~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	~ KIND, either express or implied. See the License for the
+	~ specific language governing permissions and limitations
+	~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.uima.fit.maven.it</groupId>
+    <artifactId>default</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>main-artifact</artifactId>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.uima.fit.maven.it</groupId>
+      <artifactId>compile-artifact</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima.fit.maven.it</groupId>
+      <artifactId>test-artifact</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+      <version>@pom.version@</version>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.uima</groupId>
+        <artifactId>uimafit-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <componentVendor>Apache UIMA</componentVendor>
+          <componentCopyright>Copyright by the respective authors.</componentCopyright>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>enhance</goal>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <addTypeSystemDescriptions>EMBEDDED</addTypeSystemDescriptions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact/src/main/java/TestAnnotator.java
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/main-artifact/src/main/java/TestAnnotator.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import org.apache.uima.analysis_component.JCasAnnotator_ImplBase;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.jcas.JCas;
+
+/**
+ * Test annotator.
+ */
+public class TestAnnotator extends JCasAnnotator_ImplBase {
+
+  @Override
+  public void process(JCas aJCas) throws AnalysisEngineProcessException {
+    // Nothing to do
+  }
+}

--- a/uimafit-maven-plugin/src/it/compile-test-scope/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/pom.xml
@@ -35,6 +35,7 @@
   
   <modules>
     <module>test-artifact</module>
+    <module>test-artifact2</module>
     <module>compile-artifact</module>
     <module>main-artifact</module>
     <module>main-artifact-plus-test-scope</module>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	~ Licensed to the Apache Software Foundation (ASF) under one
+	~ or more contributor license agreements. See the NOTICE file
+	~ distributed with this work for additional information
+	~ regarding copyright ownership. The ASF licenses this file
+	~ to you under the Apache License, Version 2.0 (the
+	~ "License"); you may not use this file except in compliance
+	~ with the License. You may obtain a copy of the License at
+	~
+	~ http://www.apache.org/licenses/LICENSE-2.0
+	~
+	~ Unless required by applicable law or agreed to in writing,
+	~ software distributed under the License is distributed on an
+	~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	~ KIND, either express or implied. See the License for the
+	~ specific language governing permissions and limitations
+	~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.uima.fit.maven.it</groupId>
+	<artifactId>default</artifactId>
+	<version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+	<properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+  
+  <modules>
+    <module>test-artifact</module>
+    <module>compile-artifact</module>
+    <module>main-artifact</module>
+    <module>main-artifact-plus-test-scope</module>
+  </modules>
+</project>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact-plus-test-scope/TestAnnotator.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact-plus-test-scope/TestAnnotator.xml
@@ -64,6 +64,16 @@
                     <supertypeName>uima.tcas.Annotation</supertypeName>
                                     
                 </typeDescription>
+                                
+                <typeDescription>
+                                        
+                    <name>org.apache.uima.fit.type.TestType2</name>
+                                        
+                    <description/>
+                                        
+                    <supertypeName>uima.tcas.Annotation</supertypeName>
+                                    
+                </typeDescription>
                             
             </types>
                     

--- a/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact-plus-test-scope/TestAnnotator.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact-plus-test-scope/TestAnnotator.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
 <analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
         
     <frameworkImplementation>org.apache.uima.java</frameworkImplementation>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact-plus-test-scope/TestAnnotator.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact-plus-test-scope/TestAnnotator.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+        
+    <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+        
+    <primitive>true</primitive>
+        
+    <annotatorImplementationName>TestAnnotator</annotatorImplementationName>
+        
+    <analysisEngineMetaData>
+                
+        <name>TestAnnotator</name>
+                
+        <description>Test annotator.</description>
+                
+        <version>1.0-SNAPSHOT</version>
+                
+        <vendor>Apache UIMA</vendor>
+                
+        <copyright>Copyright by the respective authors.</copyright>
+                
+        <configurationParameters/>
+                
+        <configurationParameterSettings/>
+                
+        <typeSystemDescription>
+                        
+            <types>
+                                
+                <typeDescription>
+                                        
+                    <name>org.apache.uima.fit.type.CompileType</name>
+                                        
+                    <description/>
+                                        
+                    <supertypeName>uima.tcas.Annotation</supertypeName>
+                                    
+                </typeDescription>
+                                
+                <typeDescription>
+                                        
+                    <name>org.apache.uima.fit.type.TestType</name>
+                                        
+                    <description/>
+                                        
+                    <supertypeName>uima.tcas.Annotation</supertypeName>
+                                    
+                </typeDescription>
+                            
+            </types>
+                    
+        </typeSystemDescription>
+                
+        <typePriorities/>
+                
+        <fsIndexCollection/>
+                
+        <capabilities/>
+                
+        <operationalProperties>
+                        
+            <modifiesCas>true</modifiesCas>
+                        
+            <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+                        
+            <outputsNewCASes>false</outputsNewCASes>
+                    
+        </operationalProperties>
+            
+    </analysisEngineMetaData>
+    
+</analysisEngineDescription>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact/TestAnnotator.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact/TestAnnotator.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+        
+    <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+        
+    <primitive>true</primitive>
+        
+    <annotatorImplementationName>TestAnnotator</annotatorImplementationName>
+        
+    <analysisEngineMetaData>
+                
+        <name>TestAnnotator</name>
+                
+        <description>Test annotator.</description>
+                
+        <version>1.0-SNAPSHOT</version>
+                
+        <vendor>Apache UIMA</vendor>
+                
+        <copyright>Copyright by the respective authors.</copyright>
+                
+        <configurationParameters/>
+                
+        <configurationParameterSettings/>
+                
+        <typeSystemDescription>
+                        
+            <types>
+                                
+                <typeDescription>
+                                        
+                    <name>org.apache.uima.fit.type.CompileType</name>
+                                        
+                    <description/>
+                                        
+                    <supertypeName>uima.tcas.Annotation</supertypeName>
+                                    
+                </typeDescription>
+                            
+            </types>
+                    
+        </typeSystemDescription>
+                
+        <typePriorities/>
+                
+        <fsIndexCollection/>
+                
+        <capabilities/>
+                
+        <operationalProperties>
+                        
+            <modifiesCas>true</modifiesCas>
+                        
+            <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+                        
+            <outputsNewCASes>false</outputsNewCASes>
+                    
+        </operationalProperties>
+            
+    </analysisEngineMetaData>
+    
+</analysisEngineDescription>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact/TestAnnotator.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/reference/main-artifact/TestAnnotator.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
 <analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
         
     <frameworkImplementation>org.apache.uima.java</frameworkImplementation>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	~ Licensed to the Apache Software Foundation (ASF) under one
+	~ or more contributor license agreements. See the NOTICE file
+	~ distributed with this work for additional information
+	~ regarding copyright ownership. The ASF licenses this file
+	~ to you under the Apache License, Version 2.0 (the
+	~ "License"); you may not use this file except in compliance
+	~ with the License. You may obtain a copy of the License at
+	~
+	~ http://www.apache.org/licenses/LICENSE-2.0
+	~
+	~ Unless required by applicable law or agreed to in writing,
+	~ software distributed under the License is distributed on an
+	~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	~ KIND, either express or implied. See the License for the
+	~ specific language governing permissions and limitations
+	~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.uima.fit.maven.it</groupId>
+    <artifactId>default</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>test-artifact</artifactId>
+</project>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact/src/main/resources/META-INF/org.apache.uima.fit/types.txt
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact/src/main/resources/META-INF/org.apache.uima.fit/types.txt
@@ -1,0 +1,1 @@
+classpath*:org/apache/uima/fit/type/testartifact/types.xml

--- a/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact/src/main/resources/org/apache/uima/fit/type/testartifact/types.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact/src/main/resources/org/apache/uima/fit/type/testartifact/types.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements. See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership. The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License. You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied. See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+  <name>Test Types</name>
+  <description></description>
+  <version>1.0</version>
+  <vendor/>
+  <types>
+    <typeDescription>
+      <name>org.apache.uima.fit.type.TestType</name>
+      <description/>
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+    </typeDescription>
+  </types>
+</typeSystemDescription>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact2/pom.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact2/pom.xml
@@ -28,13 +28,5 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
   
-  <artifactId>test-artifact</artifactId>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.uima.fit.maven.it</groupId>
-      <artifactId>test-artifact2</artifactId>
-      <version>1.0-SNAPSHOT</version>
-    </dependency>
-  </dependencies>
+  <artifactId>test-artifact2</artifactId>
 </project>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact2/src/main/resources/META-INF/org.apache.uima.fit/types.txt
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact2/src/main/resources/META-INF/org.apache.uima.fit/types.txt
@@ -1,0 +1,1 @@
+classpath*:org/apache/uima/fit/type/testartifact2/types.xml

--- a/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact2/src/main/resources/org/apache/uima/fit/type/testartifact2/types.xml
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/test-artifact2/src/main/resources/org/apache/uima/fit/type/testartifact2/types.xml
@@ -18,17 +18,14 @@
 	under the License.
 -->
 <typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
-  <name>Test Types</name>
-  <description />
+  <name>Test Types 2</name>
+  <description></description>
   <version>1.0</version>
-  <vendor />
-  <imports>
-    <import name="org.apache.uima.fit.type.testartifact2.types" />
-  </imports>
+  <vendor/>
   <types>
     <typeDescription>
-      <name>org.apache.uima.fit.type.TestType</name>
-      <description />
+      <name>org.apache.uima.fit.type.TestType2</name>
+      <description/>
       <supertypeName>uima.tcas.Annotation</supertypeName>
     </typeDescription>
   </types>

--- a/uimafit-maven-plugin/src/it/compile-test-scope/verify.bsh
+++ b/uimafit-maven-plugin/src/it/compile-test-scope/verify.bsh
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.regex.*;
+import org.apache.commons.io.*;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
+
+try
+{
+  String reference = IOUtils.toString(new File(basedir, 
+    "reference/main-artifact/TestAnnotator.xml").toURI().toURL());
+  String actual = IOUtils.toString(new File(basedir, 
+    "main-artifact/target/classes/TestAnnotator.xml").toURI().toURL());
+
+  // In a local build, I get indented XML but on the Apache Jenkins I get non-indented XML. This
+  // settings tells XMLUnit to ignore this difference in whitespace - rec 2013-02-16
+  XMLUnit.setIgnoreWhitespace(true);
+  Diff diff = XMLUnit.compareXML(reference, actual);
+
+  if (!diff.identical()) {
+        System.out.println("Actual descriptor does not match expected descriptor: " + diff);
+        return false;
+  }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+try
+{
+  String reference = IOUtils.toString(new File(basedir, 
+    "reference/main-artifact-plus-test-scope/TestAnnotator.xml").toURI().toURL());
+  String actual = IOUtils.toString(new File(basedir, 
+    "main-artifact-plus-test-scope/target/classes/TestAnnotator.xml").toURI().toURL());
+
+  // In a local build, I get indented XML but on the Apache Jenkins I get non-indented XML. This
+  // settings tells XMLUnit to ignore this difference in whitespace - rec 2013-02-16
+  XMLUnit.setIgnoreWhitespace(true);
+  Diff diff = XMLUnit.compareXML(reference, actual);
+
+  if (!diff.identical()) {
+        System.out.println("Actual descriptor does not match expected descriptor: " + diff);
+        return false;
+  }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/EnhanceMojo.java
+++ b/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/EnhanceMojo.java
@@ -19,6 +19,8 @@
 package org.apache.uima.fit.maven;
 
 import static org.apache.commons.lang.exception.ExceptionUtils.getRootCauseMessage;
+import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_CLASSES;
+import static org.apache.maven.plugins.annotations.ResolutionScope.TEST;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -41,10 +43,8 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.uima.fit.descriptor.ResourceMetaData;
 import org.apache.uima.fit.factory.ConfigurationParameterFactory;
@@ -75,7 +75,7 @@ import javassist.bytecode.annotation.StringMemberValue;
 /**
  * Enhance UIMA components with automatically generated uimaFIT annotations.
  */
-@Mojo(name = "enhance", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE, requiresDependencyCollection = ResolutionScope.COMPILE)
+@Mojo(name = "enhance", defaultPhase = PROCESS_CLASSES, requiresDependencyResolution = TEST, requiresDependencyCollection = TEST)
 public class EnhanceMojo extends AbstractMojo {
   @Component
   private MavenProject project;

--- a/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/GenerateDescriptorsMojo.java
+++ b/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/GenerateDescriptorsMojo.java
@@ -18,6 +18,8 @@
  */
 package org.apache.uima.fit.maven;
 
+import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_CLASSES;
+import static org.apache.maven.plugins.annotations.ResolutionScope.TEST;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
 import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
 
@@ -32,10 +34,8 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.collection.CollectionReaderDescription;
@@ -53,7 +53,7 @@ import org.xml.sax.SAXException;
 /**
  * Generate descriptor files for uimaFIT-based UIMA components.
  */
-@Mojo(name = "generate", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE, requiresDependencyCollection = ResolutionScope.COMPILE)
+@Mojo(name = "generate", defaultPhase = PROCESS_CLASSES, requiresDependencyResolution = TEST, requiresDependencyCollection = TEST)
 public class GenerateDescriptorsMojo extends AbstractMojo {
   @Component
   private MavenProject project;

--- a/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/GenerateDescriptorsMojo.java
+++ b/uimafit-maven-plugin/src/main/java/org/apache/uima/fit/maven/GenerateDescriptorsMojo.java
@@ -18,6 +18,9 @@
  */
 package org.apache.uima.fit.maven;
 
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -36,8 +39,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.collection.CollectionReaderDescription;
-import org.apache.uima.fit.factory.AnalysisEngineFactory;
-import org.apache.uima.fit.factory.CollectionReaderFactory;
 import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
 import org.apache.uima.fit.maven.util.Util;
 import org.apache.uima.resource.ResourceCreationSpecifier;
@@ -97,6 +98,13 @@ public class GenerateDescriptorsMojo extends AbstractMojo {
   @Parameter(defaultValue = "NONE")
   private TypeSystemSerialization addTypeSystemDescriptions;
 
+  /**
+   * Scope threshold to include. The default is "compile" (which implies compile, provided and
+   * system dependencies). Can also be changed to "test" (which implies all dependencies).
+   */
+  @Parameter(defaultValue = "compile", required = true)
+  private String includeScope;
+
   @Override
   public void execute() throws MojoExecutionException {
     // add the generated sources to the build
@@ -109,7 +117,7 @@ public class GenerateDescriptorsMojo extends AbstractMojo {
     String[] files = FileUtils.getFilesFromExtension(project.getBuild().getOutputDirectory(),
             new String[] { "class" });
 
-    componentLoader = Util.getClassloader(project, getLog());
+    componentLoader = Util.getClassloader(project, getLog(), includeScope);
 
     // List of components that is later written to META-INF/org.apache.uima.fit/components.txt
     StringBuilder componentsManifest = new StringBuilder();
@@ -136,13 +144,12 @@ public class GenerateDescriptorsMojo extends AbstractMojo {
         ProcessingResourceMetaData metadata = null;
         switch (Util.getType(componentLoader, clazz)) {
           case ANALYSIS_ENGINE:
-            AnalysisEngineDescription aeDesc = AnalysisEngineFactory.createEngineDescription(clazz);
+            AnalysisEngineDescription aeDesc = createEngineDescription(clazz);
             metadata = aeDesc.getAnalysisEngineMetaData();
             desc = aeDesc;
             break;
           case COLLECTION_READER:
-            CollectionReaderDescription crDesc = CollectionReaderFactory
-                    .createReaderDescription(clazz);
+            CollectionReaderDescription crDesc = createReaderDescription(clazz);
             metadata = crDesc.getCollectionReaderMetaData();
             desc = crDesc;
           default:


### PR DESCRIPTION
- [x] Add "includeScope" parameter to enhance and generate mojos with default value "compile"
- [x] Add integration tests checking that the new parameter works as expected for the "test" and "compile" scopes
- [x] Add test that checks that imports in a test dependency are also properly resolved

**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6396
