### PR TITLE
[UIMA-6432] Upgrade dependencies

### DIFF
--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -48,6 +48,7 @@
     <commons-io-version>2.11.0</commons-io-version>
     <commons-lang3-version>3.12.0</commons-lang3-version>
     <junit-version>5.8.2</junit-version>
+    <groovy-version>3.0.10</groovy-version>
     <mockito-version>4.4.0</mockito-version>
     <spring-version>5.3.18</spring-version>
     <slf4j-version>1.7.36</slf4j-version>
@@ -233,7 +234,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-jsr223</artifactId>
-            <version>2.5.16</version>
+            <version>${groovy-version}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -292,7 +293,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.10</version>
+            <version>${groovy-version}</version>
             <type>pom</type>
           </dependency>
         </dependencies>

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -40,15 +40,19 @@
     <url>https://github.com/apache/uima-uimafit</url>
   </scm>
   <properties>
-    <spring-version>4.3.30.RELEASE</spring-version>
-    <uima-version>3.3.0-SNAPSHOT</uima-version>
-    <slf4j-version>1.7.36</slf4j-version>
-    <junit-version>5.8.2</junit-version>
-    <assertj-version>3.22.0</assertj-version>
-    <xmlunit-version>2.9.0</xmlunit-version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <api_check_oldVersion>3.1.0</api_check_oldVersion>
+  
+    <assertj-version>3.22.0</assertj-version>
+    <commons-io-version>2.11.0</commons-io-version>
+    <commons-lang3-version>3.12.0</commons-lang3-version>
+    <junit-version>5.8.2</junit-version>
+    <mockito-version>4.4.0</mockito-version>
+    <spring-version>5.3.18</spring-version>
+    <slf4j-version>1.7.36</slf4j-version>
+    <uima-version>3.3.0-SNAPSHOT</uima-version>
+    <xmlunit-version>2.9.0</xmlunit-version>
   </properties>
   <repositories>
     <!--
@@ -151,17 +155,17 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.2.4</version>
+        <version>${mockito-version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.12.0</version>
+        <version>${commons-lang3-version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
+        <version>${commons-io-version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -224,12 +228,12 @@
         <!-- See: https://issues.apache.org/jira/browse/UIMA-6351 -->
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.15.3</version>
+        <version>0.15.7</version>
         <dependencies>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-jsr223</artifactId>
-            <version>2.5.14</version>
+            <version>2.5.16</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -288,7 +292,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.7</version>
+            <version>3.0.10</version>
             <type>pom</type>
           </dependency>
         </dependencies>
@@ -307,7 +311,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>1.6</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>
@@ -343,14 +347,14 @@
             <dependency>
               <groupId>org.apache.maven.doxia</groupId>
               <artifactId>doxia-core</artifactId>
-              <version>1.7</version>
+              <version>1.11.1</version>
             </dependency>
           </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.1</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>
@@ -360,7 +364,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.3.2</version>
           <executions>
             <execution>
               <id>attach-javadocs</id>
@@ -409,7 +413,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0</version>
           <executions>
             <execution>
               <id>enforce-prerequisites</id>


### PR DESCRIPTION
- Spring 4.3.30 -> 5.3.18
- Commons IO 2.8.0 -> 2.11.0
- Mockito 3.2.4 -> 4.4.0 (test)
- japicmp-maven-plugin 0.15.3 -> 0.15.7 (build)
- groovy-jsr223 2.5.14 -> 3.0.10 (build)
- groovy-all 3.0.7 -> 3.0.10 (build)
- maven-gpg-plugin 1.6 -> 3.0.1 (build)
- doxia-core 1.7 -> 1.11.1 (build)
- maven-compiler-plugin 3.8.1 -> 3.10.1 (build)
- maven-javadoc-plugin 3.1.0 -> 3.3.2 (build)
- maven-enforcer-plugin 3.0.0-M3 -> 3.0.0 (build)
