### PR TITLE
[UIMA-6452] Some tests fail cleaning up their temporary data

### DIFF
--- a/uimafit-core/src/test/java/org/apache/uima/fit/component/CasDumpWriterTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/component/CasDumpWriterTest.java
@@ -18,17 +18,21 @@
  */
 package org.apache.uima.fit.component;
 
+import static java.nio.file.Files.newInputStream;
 import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.pipeline.SimplePipeline.runPipeline;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.uima.analysis_engine.AnalysisEngine;
-import org.apache.uima.fit.factory.AnalysisEngineFactory;
-import org.apache.uima.fit.util.CasIOUtil;
 import org.apache.uima.jcas.JCas;
+import org.apache.uima.util.CasIOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,11 +42,14 @@ public class CasDumpWriterTest {
   public void test(@TempDir Path folder) throws Exception {
     File outputFile = folder.resolve("dump-output.txt").toFile();
 
-    AnalysisEngine writer = AnalysisEngineFactory.createEngine(CasDumpWriter.class,
+    AnalysisEngine writer = createEngine(CasDumpWriter.class, //
             CasDumpWriter.PARAM_OUTPUT_FILE, outputFile.getPath());
+
     JCas jcas = writer.newJCas();
-    CasIOUtil.readJCas(jcas, new File("src/test/resources/data/docs/test.xmi"));
-    writer.process(jcas);
+    try (InputStream is = newInputStream(Paths.get("src/test/resources/data/docs/test.xmi"))) {
+        CasIOUtils.load(is, jcas.getCas());
+    }
+    runPipeline(jcas, writer);
     assertTrue(outputFile.exists());
 
     String reference = readFileToString(new File("src/test/resources/data/reference/test.xmi.dump"),

--- a/uimafit-core/src/test/java/org/apache/uima/fit/component/CasDumpWriterTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/component/CasDumpWriterTest.java
@@ -20,7 +20,7 @@ package org.apache.uima.fit.component;
 
 import static java.nio.file.Files.newInputStream;
 import static org.apache.commons.io.FileUtils.readFileToString;
-import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
 import static org.apache.uima.fit.pipeline.SimplePipeline.runPipeline;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,7 +30,8 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.util.CasIOUtils;
 import org.junit.jupiter.api.Test;
@@ -42,10 +43,10 @@ public class CasDumpWriterTest {
   public void test(@TempDir Path folder) throws Exception {
     File outputFile = folder.resolve("dump-output.txt").toFile();
 
-    AnalysisEngine writer = createEngine(CasDumpWriter.class, //
+    AnalysisEngineDescription writer = createEngineDescription(CasDumpWriter.class, //
             CasDumpWriter.PARAM_OUTPUT_FILE, outputFile.getPath());
 
-    JCas jcas = writer.newJCas();
+    JCas jcas = JCasFactory.createJCas();
     try (InputStream is = newInputStream(Paths.get("src/test/resources/data/docs/test.xmi"))) {
         CasIOUtils.load(is, jcas.getCas());
     }

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/JCasBuilderTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/JCasBuilderTest.java
@@ -19,14 +19,14 @@
 package org.apache.uima.fit.factory;
 
 import static org.apache.commons.io.FileUtils.readFileToString;
-import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
 import static org.apache.uima.fit.pipeline.SimplePipeline.runPipeline;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.file.Path;
 
-import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.fit.ComponentTestBase;
 import org.apache.uima.fit.component.CasDumpWriter;
 import org.apache.uima.fit.type.Sentence;
@@ -55,7 +55,7 @@ public class JCasBuilderTest extends ComponentTestBase {
     jb.close();
 
     File outputFile = folder.resolve("dump-output.txt").toFile();
-    AnalysisEngine writer = createEngine(CasDumpWriter.class, //
+    AnalysisEngineDescription writer = createEngineDescription(CasDumpWriter.class, //
             CasDumpWriter.PARAM_OUTPUT_FILE, outputFile.getPath());
     runPipeline(jb.getJCas(), writer);
 

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/JCasBuilderTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/JCasBuilderTest.java
@@ -20,6 +20,7 @@ package org.apache.uima.fit.factory;
 
 import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.pipeline.SimplePipeline.runPipeline;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -56,7 +57,7 @@ public class JCasBuilderTest extends ComponentTestBase {
     File outputFile = folder.resolve("dump-output.txt").toFile();
     AnalysisEngine writer = createEngine(CasDumpWriter.class, //
             CasDumpWriter.PARAM_OUTPUT_FILE, outputFile.getPath());
-    writer.process(jb.getJCas());
+    runPipeline(jb.getJCas(), writer);
 
     String reference = readFileToString(
             new File("src/test/resources/data/reference/JCasBuilderTest.dump"), "UTF-8").trim();


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6452

**What's in the PR**
- Use runPipeline instead of simply calling engine.process() to ensure that the collectionProcessComplete() lifecycle method is called which then closes the output stream held by the CasDumpWriter and which should then allow the file to be deleted on Windows

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
