### PR TITLE
#195 - Detect descriptors via SPI

### DIFF
--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -166,6 +166,9 @@
                   <exclude>src/test/resources/META-INF/org.apache.uima.fit/typepriorities.txt</exclude>
                   <exclude>src/test/resources/META-INF/org.apache.uima.fit/types.txt</exclude>
                   <exclude>src/test/resources/META-INF/services/org.apache.uima.fit.validation.ValidationCheck</exclude>
+                  <exclude>src/test/resources/META-INF/services/org.apache.uima.spi.FsIndexCollectionProvider</exclude>
+                  <exclude>src/test/resources/META-INF/services/org.apache.uima.spi.TypePrioritiesProvider</exclude>
+                  <exclude>src/test/resources/META-INF/services/org.apache.uima.spi.TypeSystemDescriptionProvider</exclude>
                 </excludes>
               </configuration>
             </execution>

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactory.java
@@ -126,7 +126,7 @@ public final class TypeSystemDescriptionFactory {
       synchronized (CREATE_LOCK) {
         List<TypeSystemDescription> tsdList = new ArrayList<>();
 
-        loadTypeSystemDscriptionsFromScannedLocations(tsdList);
+        loadTypeSystemDescriptionsFromScannedLocations(tsdList);
         loadTypeSystemDescriptionsFromSPIs(tsdList);
 
         LOG.trace("Merging type systems and resolving imports...");
@@ -138,7 +138,7 @@ public final class TypeSystemDescriptionFactory {
     return (TypeSystemDescription) tsd.clone();
   }
 
-  static void loadTypeSystemDscriptionsFromScannedLocations(List<TypeSystemDescription> tsdList)
+  static void loadTypeSystemDescriptionsFromScannedLocations(List<TypeSystemDescription> tsdList)
           throws ResourceInitializationException {
     for (String location : scanTypeDescriptors()) {
       try {

--- a/uimafit-core/src/test/java/org/apache/uima/fit/ComponentTestBase.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/ComponentTestBase.java
@@ -47,9 +47,10 @@ public class ComponentTestBase {
     try {
       TYPE_SYSTEM_DESCRIPTION.set(TypeSystemDescriptionFactory.createTypeSystemDescription());
 
-      TypePriorities tp = TypePrioritiesFactory
-              .createTypePriorities(new String[] { "org.apache.uima.fit.type.Sentence",
-                  "org.apache.uima.fit.type.AnalyzedText", "org.apache.uima.fit.type.Token" });
+      TypePriorities tp = TypePrioritiesFactory.createTypePriorities( //
+              "org.apache.uima.fit.type.Sentence", //
+              "org.apache.uima.fit.type.AnalyzedText", //
+              "org.apache.uima.fit.type.Token");
       TYPE_PRIORITIES.set(tp);
 
       JCas jCas = CasCreationUtils.createCas(TYPE_SYSTEM_DESCRIPTION.get(), tp, null).getJCas();

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/AnalysisEngineFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/AnalysisEngineFactoryTest.java
@@ -26,8 +26,10 @@ import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineFrom
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.generateDelegateKey;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.sanitizeDelegateKey;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.apache.uima.resource.metadata.FsIndexDescription.KIND_SORTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -59,6 +61,8 @@ import org.apache.uima.fit.component.JCasAnnotator_ImplBase;
 import org.apache.uima.fit.component.NoOpAnnotator;
 import org.apache.uima.fit.descriptor.OperationalProperties;
 import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.fit.factory.spi.FsIndexCollectionProviderForTesting;
+import org.apache.uima.fit.factory.spi.TypePrioritiesProviderForTesting;
 import org.apache.uima.fit.factory.testAes.Annotator1;
 import org.apache.uima.fit.factory.testAes.Annotator2;
 import org.apache.uima.fit.factory.testAes.Annotator3;
@@ -115,7 +119,8 @@ public class AnalysisEngineFactoryTest extends ComponentTestBase {
 
   @Test
   public void testCreateAnalysisEngineWithPrioritizedTypes() throws UIMAException {
-    String[] prioritizedTypeNames = new String[] { "org.apache.uima.fit.type.Token",
+    String[] prioritizedTypeNames = new String[] { //
+        "org.apache.uima.fit.type.Token", //
         "org.apache.uima.fit.type.Sentence" };
     AnalysisEngine engine = AnalysisEngineFactory.createEngine(
             org.apache.uima.fit.component.NoOpAnnotator.class, typeSystemDescription,
@@ -474,7 +479,8 @@ public class AnalysisEngineFactoryTest extends ComponentTestBase {
 
   @Test
   public void testResourceMetaDataOnParentIgnored() throws Exception {
-    AnalysisEngineDescription desc = createEngineDescription(AnnotatorWithMetaDataClassOnParent.class);
+    AnalysisEngineDescription desc = createEngineDescription(
+            AnnotatorWithMetaDataClassOnParent.class);
 
     org.apache.uima.resource.metadata.ResourceMetaData meta = desc.getMetaData();
 
@@ -628,24 +634,40 @@ public class AnalysisEngineFactoryTest extends ComponentTestBase {
     AnalysisEngineDescription aed = createEngineDescription(NoOpAnnotator.class);
 
     TypeSystemDescription tsd = createTypeSystemDescription();
-    assertThat(tsd.getType(Token.class.getName())).as("Token type auto-detection").isNotNull();
-    assertThat(tsd.getType(Sentence.class.getName())).as("Sentence type auto-detection")
+    assertThat(tsd.getType(Token.class.getName())) //
+            .as("Token type auto-detection") //
             .isNotNull();
-    assertThat(tsd.getType(AnalyzedText.class.getName())).as("AnalyzedText type auto-detection")
+    assertThat(tsd.getType(Sentence.class.getName())) //
+            .as("Sentence type auto-detection") //
+            .isNotNull();
+    assertThat(tsd.getType(AnalyzedText.class.getName())) //
+            .as("AnalyzedText type auto-detection") //
             .isNotNull();
 
-    TypePriorityList[] typePrioritiesLists = typePriorities.getPriorityLists();
-    assertThat(typePrioritiesLists.length).isEqualTo(1);
-    assertThat(typePrioritiesLists[0].getTypes()).as("Type priorities auto-detection")
-            .containsExactly(Sentence.class.getName(), AnalyzedText.class.getName(),
-                    Token.class.getName());
+    assertThat(aed.getAnalysisEngineMetaData().getTypePriorities().getPriorityLists()) //
+            .as("Type priorities auto-detection")//
+            .extracting(TypePriorityList::getTypes) //
+            .containsExactlyInAnyOrder( //
+                    new String[] { //
+                        TypePrioritiesProviderForTesting.TEST_TYPE_A },
+                    new String[] { //
+                        Sentence.class.getName(), //
+                        Token.class.getName() });
 
-    FsIndexDescription[] indexes = aed.getAnalysisEngineMetaData().getFsIndexCollection()
-            .getFsIndexes();
-    assertThat(indexes.length).isEqualTo(1);
-    assertThat(indexes[0]).extracting(FsIndexDescription::getLabel, FsIndexDescription::getTypeName,
-            FsIndexDescription::getKind).containsExactly("Automatically Scanned Index",
-                    Token.class.getName(), FsIndexDescription.KIND_SORTED);
+    assertThat(aed.getAnalysisEngineMetaData().getFsIndexCollection().getFsIndexes()) //
+            .extracting( //
+                    FsIndexDescription::getLabel, //
+                    FsIndexDescription::getTypeName, //
+                    FsIndexDescription::getKind) //
+            .containsExactlyInAnyOrder( //
+                    tuple( //
+                            "Automatically Scanned Index", //
+                            Token.class.getName(), //
+                            KIND_SORTED),
+                    tuple( //
+                            FsIndexCollectionProviderForTesting.INDEX_LABEL, //
+                            FsIndexCollectionProviderForTesting.INDEX_TYPE, //
+                            KIND_SORTED));
   }
 
   @Test

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactoryTest.java
@@ -20,7 +20,7 @@ package org.apache.uima.fit.factory;
 
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.loadTypeSystemDescriptionsFromSPIs;
-import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.loadTypeSystemDscriptionsFromScannedLocations;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.loadTypeSystemDescriptionsFromScannedLocations;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
@@ -55,7 +55,7 @@ public class TypeSystemDescriptionFactoryTest {
   @Test
   public void testLoadingFromScannedLocations() throws Exception {
     List<TypeSystemDescription> tsds = new ArrayList<>();
-    loadTypeSystemDscriptionsFromScannedLocations(tsds);
+    loadTypeSystemDescriptionsFromScannedLocations(tsds);
     TypeSystemDescription tsd = CasCreationUtils.mergeTypeSystems(tsds);
 
     assertNotNull(tsd.getType(Token.class.getName()));

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactoryTest.java
@@ -19,16 +19,21 @@
 package org.apache.uima.fit.factory;
 
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.loadTypeSystemDescriptionsFromSPIs;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.loadTypeSystemDscriptionsFromScannedLocations;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.uima.fit.factory.spi.TypeSystemDescriptionProviderForTesting;
 import org.apache.uima.fit.type.AnalyzedText;
 import org.apache.uima.fit.type.Sentence;
 import org.apache.uima.fit.type.Token;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.Test;
 
-/**
- */
 public class TypeSystemDescriptionFactoryTest {
   @Test
   public void testFromPath() throws Exception {
@@ -44,5 +49,26 @@ public class TypeSystemDescriptionFactoryTest {
     assertNotNull(tsd.getType(Token.class.getName()));
     assertNotNull(tsd.getType(Sentence.class.getName()));
     assertNotNull(tsd.getType(AnalyzedText.class.getName()));
+    assertNotNull(tsd.getType(TypeSystemDescriptionProviderForTesting.TEST_TYPE_A));
+  }
+
+  @Test
+  public void testLoadingFromScannedLocations() throws Exception {
+    List<TypeSystemDescription> tsds = new ArrayList<>();
+    loadTypeSystemDscriptionsFromScannedLocations(tsds);
+    TypeSystemDescription tsd = CasCreationUtils.mergeTypeSystems(tsds);
+
+    assertNotNull(tsd.getType(Token.class.getName()));
+    assertNotNull(tsd.getType(Sentence.class.getName()));
+    assertNotNull(tsd.getType(AnalyzedText.class.getName()));
+  }
+
+  @Test
+  public void testLoadingFromSPIs() throws Exception {
+    List<TypeSystemDescription> tsds = new ArrayList<>();
+    loadTypeSystemDescriptionsFromSPIs(tsds);
+    TypeSystemDescription tsd = CasCreationUtils.mergeTypeSystems(tsds);
+
+    assertNotNull(tsd.getType(TypeSystemDescriptionProviderForTesting.TEST_TYPE_A));
   }
 }

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/FsIndexCollectionProviderForTesting.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/FsIndexCollectionProviderForTesting.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.fit.factory.spi;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import org.apache.uima.ResourceSpecifierFactory;
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.resource.metadata.FsIndexCollection;
+import org.apache.uima.resource.metadata.FsIndexDescription;
+import org.apache.uima.spi.FsIndexCollectionProvider;
+
+public class FsIndexCollectionProviderForTesting implements FsIndexCollectionProvider {
+
+  public static final String INDEX_LABEL = "SPI-defined Scanned Index";
+  public static final String INDEX_TYPE = "test.TypeA";
+
+  @Override
+  public List<FsIndexCollection> listFsIndexCollections() {
+    ResourceSpecifierFactory factory = UIMAFramework.getResourceSpecifierFactory();
+    FsIndexCollection fsIndexCollection = factory.createFsIndexCollection();
+    FsIndexDescription index = factory.createFsIndexDescription();
+    index.setTypeName(INDEX_TYPE);
+    index.setLabel(INDEX_LABEL);
+    index.setKind(FsIndexDescription.KIND_SORTED);
+    fsIndexCollection.addFsIndex(index);
+    return asList(fsIndexCollection);
+  }
+}

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/MyAdvancedTypeSystemProvider.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/MyAdvancedTypeSystemProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// Used as an example in the documentation
+package org.apache.uima.fit.factory.spi;
+
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.resource.ResourceManager;
+import org.apache.uima.resource.impl.ResourceManager_impl;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import org.apache.uima.util.InvalidXMLException;
+
+public class MyAdvancedTypeSystemProvider implements TypeSystemDescriptionProvider {
+
+  @Override
+  public List<TypeSystemDescription> listTypeSystemDescriptions() {
+    ResourceManager resMgr = new ResourceManager_impl(getClass().getClassLoader());
+    try {
+      TypeSystemDescription tsd = createTypeSystemDescription(
+              "org.apache.uima.examples.types.TypeSystem");
+      tsd.resolveImports(resMgr);
+      return asList(tsd);
+    } catch (InvalidXMLException e) {
+      UIMAFramework.getLogger().error("Unable to load type system", e);
+      return Collections.emptyList();
+    } finally {
+      resMgr.destroy();
+    }
+  }
+}

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/MyTypeSystemProvider.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/MyTypeSystemProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// Used as an example in the documentation
+package org.apache.uima.fit.factory.spi;
+
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+
+import java.util.List;
+
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.spi.TypeSystemDescriptionProvider;
+
+public class MyTypeSystemProvider implements TypeSystemDescriptionProvider {
+
+  @Override
+  public List<TypeSystemDescription> listTypeSystemDescriptions() {
+    return asList(createTypeSystemDescription("org.apache.uima.examples.types.TypeSystem"));
+  }
+}

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/TypePrioritiesProviderForTesting.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/TypePrioritiesProviderForTesting.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.fit.factory.spi;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.resource.metadata.TypePriorities;
+import org.apache.uima.spi.TypePrioritiesProvider;
+
+public class TypePrioritiesProviderForTesting implements TypePrioritiesProvider {
+
+  public static final String TEST_TYPE_A = "test.TypeA";
+
+  @Override
+  public List<TypePriorities> listTypePriorities() {
+    TypePriorities prios = UIMAFramework.getResourceSpecifierFactory().createTypePriorities();
+    prios.addPriorityList().addType(TEST_TYPE_A);
+    return asList(prios);
+  }
+}

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/TypeSystemDescriptionProviderForTesting.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/spi/TypeSystemDescriptionProviderForTesting.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.uima.fit.factory.spi;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.spi.TypeSystemDescriptionProvider;
+
+public class TypeSystemDescriptionProviderForTesting implements TypeSystemDescriptionProvider {
+
+  public static final String TEST_TYPE_A = "test.TypeA";
+
+  @Override
+  public List<TypeSystemDescription> listTypeSystemDescriptions() {
+    TypeSystemDescription tsd = UIMAFramework.getResourceSpecifierFactory()
+            .createTypeSystemDescription();
+    tsd.addType(TEST_TYPE_A, "", CAS.TYPE_NAME_ANNOTATION);
+    return asList(tsd);
+  }
+}

--- a/uimafit-core/src/test/resources/META-INF/services/org.apache.uima.spi.FsIndexCollectionProvider
+++ b/uimafit-core/src/test/resources/META-INF/services/org.apache.uima.spi.FsIndexCollectionProvider
@@ -1,0 +1,1 @@
+org.apache.uima.fit.factory.spi.FsIndexCollectionProviderForTesting

--- a/uimafit-core/src/test/resources/META-INF/services/org.apache.uima.spi.TypePrioritiesProvider
+++ b/uimafit-core/src/test/resources/META-INF/services/org.apache.uima.spi.TypePrioritiesProvider
@@ -1,0 +1,1 @@
+org.apache.uima.fit.factory.spi.TypePrioritiesProviderForTesting

--- a/uimafit-core/src/test/resources/META-INF/services/org.apache.uima.spi.TypeSystemDescriptionProvider
+++ b/uimafit-core/src/test/resources/META-INF/services/org.apache.uima.spi.TypeSystemDescriptionProvider
@@ -1,0 +1,1 @@
+org.apache.uima.fit.factory.spi.TypeSystemDescriptionProviderForTesting

--- a/uimafit-core/src/test/resources/data/reference/SerializationTestAnnotator.xml
+++ b/uimafit-core/src/test/resources/data/reference/SerializationTestAnnotator.xml
@@ -46,12 +46,20 @@
                         </featureDescription>
                     </features>
                 </typeDescription>
+                <typeDescription>
+                    <name>test.TypeA</name>
+                    <description/>
+                    <supertypeName>uima.tcas.Annotation</supertypeName>
+                </typeDescription>
             </types>
         </typeSystemDescription>
         <typePriorities>
             <priorityList>
                 <type>org.apache.uima.fit.type.Sentence</type>
                 <type>org.apache.uima.fit.type.Token</type>
+            </priorityList>
+            <priorityList>
+                <type>test.TypeA</type>
             </priorityList>
         </typePriorities>
         <fsIndexCollection>
@@ -70,6 +78,11 @@
                             <comparator>standard</comparator>
                         </fsIndexKey>
                     </keys>
+                </fsIndexDescription>
+                <fsIndexDescription>
+                    <label>SPI-defined Scanned Index</label>
+                    <typeName>test.TypeA</typeName>
+                    <kind>sorted</kind>
                 </fsIndexDescription>
             </fsIndexes>
         </fsIndexCollection>

--- a/uimafit-doc/src/main/asciidoc/tools.uimafit.typesystem.adoc
+++ b/uimafit-doc/src/main/asciidoc/tools.uimafit.typesystem.adoc
@@ -25,6 +25,95 @@ Thus is becomes possible for a UIMA component provider to have component's type 
 
 == Making types auto-detectable
 
+=== Using the Java Service Provide Interface
+
+The Java Service Provide Interface (SPI) mechanism is a standard approach in Java for building
+extensible software. In our case, we want to make uimaFIT aware of type system descriptions, index
+definitions or type priority lists so that when we create a new CAS or analysis component, they are
+automatically pre-configured with these.
+
+To enable this auto-detection, the UIMA Core Java SDK provides defines interfaces:
+
+* `org.apache.uima.spi.FsIndexCollectionProvider`
+* `org.apache.uima.spi.TypePrioritiesProvider`
+* `org.apache.uima.spi.TypeSystemDescriptionProvider`
+
+Java code that wants to announce types, indexes or type priorities must implement one or more of
+these interfaces in a provider class. We will make an example for type system descriptions. It works
+in the same way for indexes and type priorities.
+
+The following provider class publishes types from a type system description XML file located it can
+access via the classpath at `/org/apache/uima/examples/types/TypeSystem.xml`:
+
+[source,java]
+----
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+
+import java.util.List;
+
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.spi.TypeSystemDescriptionProvider;
+
+public class MyTypeSystemProvider implements TypeSystemDescriptionProvider {
+
+  @Override
+  public List<TypeSystemDescription> listTypeSystemDescriptions() {
+    return asList(createTypeSystemDescription("org.apache.uima.examples.types.TypeSystem"));
+  }
+}
+----
+
+You may also consider a slightly more advanced implementation that pre-resolves any imports that
+may be contained in the loaded descriptors. This is important if you are in an environment with
+multiple classloaders such as an OSGI environment.
+
+[source,java]
+----
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.resource.ResourceManager;
+import org.apache.uima.resource.impl.ResourceManager_impl;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import org.apache.uima.util.InvalidXMLException;
+
+public class MyAdvancedTypeSystemProvider implements TypeSystemDescriptionProvider {
+
+  @Override
+  public List<TypeSystemDescription> listTypeSystemDescriptions() {
+    ResourceManager resMgr = new ResourceManager_impl(getClass().getClassLoader());
+    try {
+      TypeSystemDescription tsd = createTypeSystemDescription(
+              "org.apache.uima.examples.types.TypeSystem");
+      tsd.resolveImports(resMgr);
+      return asList(tsd);
+    } catch (InvalidXMLException e) {
+      UIMAFramework.getLogger().error("Unable to load type system", e);
+      return Collections.emptyList();
+    } finally {
+      resMgr.destroy();
+    }
+  }
+}
+----
+
+In a proper implementation, you might care to use a better error handling, use your own loggers
+instead of the framework logger, maybe load additional type system descriptions, etc.
+
+Once the provider class has been implemented, it needs to be registered with the SPI mechanism.
+To do that, create a text file with the name of the implemented interface in `META-INF/services`, e.g.
+`META-INF/services/org.apache.uima.spi.TypeSystemDescriptionProvider`. Into that file, add the name of
+the provider class implementation, e.g. `foo.bar.MyTypeSystemProvider`. If you have multiple provider
+classes for the given interface, add them all, one class per line.
+
+=== Legacy approach
+
 The provider of a type system should create a file [path]_META-INF/org.apache.uima.fit/types.txt_ in the classpath.
 This file should define the locations of the type system descriptions.
 Assume that a type `org.apache.uima.fit.type.Token` is specified in the TSD [path]_org/apache/uima/fit/type/Token.xml_, then the file should have the following contents:

--- a/uimafit-parent/pom.xml
+++ b/uimafit-parent/pom.xml
@@ -52,7 +52,7 @@
     <mockito-version>4.4.0</mockito-version>
     <spring-version>5.3.20</spring-version>
     <slf4j-version>1.7.36</slf4j-version>
-    <uima-version>3.3.0</uima-version>
+    <uima-version>3.4.0-SNAPSHOT</uima-version>
     <xmlunit-version>2.9.0</xmlunit-version>
   </properties>
 


### PR DESCRIPTION
**What's in the PR**
- Add ability to pick up type system descriptors, fsindex declarations and type prios via SPI

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [x] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
