### PR TITLE
No issue: Relax CPE test condition

### DIFF
--- a/uimafit-cpe/src/test/java/org/apache/uima/fit/cpe/CpePipelineFailureHandlingTest.java
+++ b/uimafit-cpe/src/test/java/org/apache/uima/fit/cpe/CpePipelineFailureHandlingTest.java
@@ -51,8 +51,9 @@ public class CpePipelineFailureHandlingTest {
       // Ignore
     }
 
-    assertThat(processed.get()).as("CPE stop processing soon after reader threw an exception")
-            .isBetween(failAfter, failAfter + getRuntime().availableProcessors());
+    assertThat(processed.get()) //
+            .as("CPE stop processing soon after reader threw an exception") //
+            .isBetween(failAfter, failAfter + (4 * getRuntime().availableProcessors()));
   }
 
   public static class Reader extends JCasCollectionReader_ImplBase {


### PR DESCRIPTION
**What's in the PR**
- On Windows, this CPE test regularly ends with a larger number of items processed ~62 - so let's relax this a bit to make the test less flaky

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
