### PR TITLE
Issue #195: Detect descriptors via SPI

### DIFF
--- a/uimafit-assertj/pom.xml
+++ b/uimafit-assertj/pom.xml
@@ -17,33 +17,53 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.uima</groupId>
-    <artifactId>uimafit-parent</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
-    <relativePath>../uimafit-parent</relativePath>
-  </parent>
-  
-  <artifactId>uimafit-assertj</artifactId>
-  <packaging>bundle</packaging>
-  
-  <name>Apache UIMA uimaFIT - AssertJ support</name>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.uima</groupId>
-      <artifactId>uimafit-core</artifactId>
-      <version>3.4.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.uima</groupId>
-      <artifactId>uimaj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-    </dependency>
-  </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.apache.uima</groupId>
+		<artifactId>uimafit-parent</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+		<relativePath>../uimafit-parent</relativePath>
+	</parent>
+
+	<artifactId>uimafit-assertj</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>Apache UIMA uimaFIT - AssertJ support</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.uima</groupId>
+			<artifactId>uimafit-core</artifactId>
+			<version>3.4.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.uima</groupId>
+			<artifactId>uimaj-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+						<Require-Capability>
+							osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional,
+							osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.fit.validation.ValidationCheck)";cardinality:=multiple;resolution:=optional
+						</Require-Capability>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/uimafit-core/pom.xml
+++ b/uimafit-core/pom.xml
@@ -113,7 +113,10 @@
             </Export-Package>
             <Require-Capability>
             	osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional,
-            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider)";cardinality:=multiple;resolution:=optional
+            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider)";cardinality:=multiple;resolution:=optional,
+            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.TypePrioritiesProvider)";cardinality:=multiple;resolution:=optional,
+            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.spi.FsIndexCollectionProvider)";cardinality:=multiple;resolution:=optional,
+            	osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.uima.fit.validation.ValidationCheck)";cardinality:=multiple;resolution:=optional
             </Require-Capability>
           </instructions>
         </configuration>


### PR DESCRIPTION
**What's in the PR**
- Complete SPI declarations
- Add SPI declarations in assertj module where the CAS validators are used

**How to test manually**
* Use the `isAvailableToServiceLoader()` assert in a OSGI-ified unit test

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
