### PR TITLE
Issue #213: Avoid broken typesystem when using ManagedCas

### DIFF
--- a/uimafit-junit/src/main/java/org/apache/uima/fit/testing/junit/ManagedCas.java
+++ b/uimafit-junit/src/main/java/org/apache/uima/fit/testing/junit/ManagedCas.java
@@ -35,6 +35,7 @@ import org.apache.uima.fit.validation.ValidationException;
 import org.apache.uima.fit.validation.ValidationSummary;
 import org.apache.uima.fit.validation.Validator;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -56,6 +57,16 @@ public final class ManagedCas implements TestWatcher, AfterTestExecutionCallback
 
   private Validator defaultValidator = new Validator.Builder().build();
   private Validator validator = null;
+
+  static {
+    try {
+      // Try creating a CAS to initialize the internal UIMA types.
+      // Workaround for: https://github.com/apache/uima-uimaj/issues/234
+      CasCreationUtils.createCas();
+    } catch (Exception e) {
+      fail("Unable to initialize UIMA");
+    }
+  }
 
   /**
    * Provides a CAS with an auto-detected type system.

--- a/uimafit-junit/src/main/java/org/apache/uima/fit/testing/junit/ManagedJCas.java
+++ b/uimafit-junit/src/main/java/org/apache/uima/fit/testing/junit/ManagedJCas.java
@@ -35,6 +35,7 @@ import org.apache.uima.fit.validation.ValidationSummary;
 import org.apache.uima.fit.validation.Validator;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -57,6 +58,16 @@ public final class ManagedJCas
 
   private Validator defaultValidator = new Validator.Builder().build();
   private Validator validator = null;
+
+  static {
+    try {
+      // Try creating a CAS to initialize the internal UIMA types.
+      // Workaround for: https://github.com/apache/uima-uimaj/issues/234
+      CasCreationUtils.createCas();
+    } catch (Exception e) {
+      fail("Unable to initialize UIMA");
+    }
+  }
 
   /**
    * Provides a JCas with an auto-detected type system.


### PR DESCRIPTION
**What's in the PR**
- Avoid UIMA bug when using Managed(J)Cas - https://github.com/apache/uima-uimaj/issues/234 - by initializing a dummy CAS in a static block.

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
