### PR TITLE
Issue #215: Improve descriptor scanning performance when there are many classloaders

### DIFF
--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
@@ -24,7 +24,9 @@ import static org.apache.uima.fit.util.CasUtil.UIMA_BUILTIN_JCAS_PREFIX;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.WeakHashMap;
 
@@ -51,11 +53,16 @@ public final class TypePrioritiesFactory {
 
   private static final Object CREATE_LOCK = new Object();
 
+  private static final TypePriorities PLACEHOLDER = new TypePriorities_impl();
+
+  private static WeakHashMap<String, TypePriorities> typePriorities;
+
   private static WeakHashMap<ClassLoader, String[]> typePrioritesLocationsByClassloader;
 
   private static WeakHashMap<ClassLoader, TypePriorities> typePrioritiesByClassloader;
 
   static {
+    typePriorities = new WeakHashMap<>();
     typePrioritesLocationsByClassloader = new WeakHashMap<>();
     typePrioritiesByClassloader = new WeakHashMap<>();
   }
@@ -97,12 +104,12 @@ public final class TypePrioritiesFactory {
    * @return type priorities created from the ordered type names
    */
   public static TypePriorities createTypePriorities(String... prioritizedTypeNames) {
-    TypePriorities typePriorities = new TypePriorities_impl();
-    TypePriorityList typePriorityList = typePriorities.addPriorityList();
+    TypePriorities priorities = new TypePriorities_impl();
+    TypePriorityList typePriorityList = priorities.addPriorityList();
     for (String typeName : prioritizedTypeNames) {
       typePriorityList.addType(typeName);
     }
-    return typePriorities;
+    return priorities;
   }
 
   /**
@@ -120,12 +127,12 @@ public final class TypePrioritiesFactory {
     TypePriorities aggTypePriorities = typePrioritiesByClassloader.get(cl);
     if (aggTypePriorities == null) {
       synchronized (CREATE_LOCK) {
+        ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
         List<TypePriorities> typePrioritiesList = new ArrayList<>();
 
-        loadTypePrioritiesFromScannedLocations(typePrioritiesList);
+        loadTypePrioritiesFromScannedLocations(typePrioritiesList, resMgr);
         loadTypePrioritiesFromSPIs(typePrioritiesList);
 
-        ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
         aggTypePriorities = CasCreationUtils.mergeTypePriorities(typePrioritiesList, resMgr);
         typePrioritiesByClassloader.put(cl, aggTypePriorities);
       }
@@ -134,14 +141,20 @@ public final class TypePrioritiesFactory {
     return (TypePriorities) aggTypePriorities.clone();
   }
 
-  static void loadTypePrioritiesFromScannedLocations(List<TypePriorities> typePrioritiesList)
-          throws ResourceInitializationException {
+  static void loadTypePrioritiesFromScannedLocations(List<TypePriorities> typePrioritiesList,
+          ResourceManager aResMgr) throws ResourceInitializationException {
     for (String location : scanTypePrioritiesDescriptors()) {
       try {
-        XMLInputSource xmlInput = new XMLInputSource(location);
-        TypePriorities typePriorities = getXMLParser().parseTypePriorities(xmlInput);
-        typePriorities.resolveImports();
-        typePrioritiesList.add(typePriorities);
+        TypePriorities priorities = typePriorities.get(location);
+
+        if (priorities == PLACEHOLDER) {
+          // If the description has not yet been loaded, load it
+          priorities = getXMLParser().parseTypePriorities(new XMLInputSource(location));
+          priorities.resolveImports(aResMgr);
+          typePriorities.put(location, priorities);
+        }
+
+        typePrioritiesList.add(priorities);
         LOG.debug("Detected type priorities at [{}]", location);
       } catch (IOException e) {
         throw new ResourceInitializationException(e);
@@ -176,9 +189,27 @@ public final class TypePrioritiesFactory {
       String[] typePrioritesLocations = typePrioritesLocationsByClassloader.get(cl);
       if (typePrioritesLocations == null) {
         typePrioritesLocations = scanDescriptors(MetaDataType.TYPE_PRIORITIES);
+        internTypePrioritiesLocations(typePrioritesLocations);
         typePrioritesLocationsByClassloader.put(cl, typePrioritesLocations);
       }
       return typePrioritesLocations;
+    }
+  }
+
+  private static void internTypePrioritiesLocations(String[] typeDescriptorLocations) {
+    // We "intern" the location strings because we will use them as keys in the WeakHashMap
+    // caching the parsed type systems. As part of this process, we put a PLACEHOLDER into the
+    // map which is replaced when the type system is actually loaded
+    Map<String, String> locationStrings = new HashMap<>();
+    typePriorities.keySet().stream().forEach(loc -> locationStrings.put(loc, loc));
+    for (int i = 0; i < typeDescriptorLocations.length; i++) {
+      String existingLocString = locationStrings.get(typeDescriptorLocations[i]);
+      if (existingLocString == null) {
+        typePriorities.put(typeDescriptorLocations[i], PLACEHOLDER);
+        locationStrings.put(typeDescriptorLocations[i], typeDescriptorLocations[i]);
+      } else {
+        typeDescriptorLocations[i] = existingLocString;
+      }
     }
   }
 
@@ -190,6 +221,7 @@ public final class TypePrioritiesFactory {
     synchronized (SCAN_LOCK) {
       typePrioritesLocationsByClassloader.clear();
       typePrioritiesByClassloader.clear();
+      typePriorities.clear();
     }
   }
 }

--- a/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
+++ b/uimafit-core/src/main/java/org/apache/uima/fit/factory/TypePrioritiesFactory.java
@@ -198,7 +198,7 @@ public final class TypePrioritiesFactory {
 
   private static void internTypePrioritiesLocations(String[] typeDescriptorLocations) {
     // We "intern" the location strings because we will use them as keys in the WeakHashMap
-    // caching the parsed type systems. As part of this process, we put a PLACEHOLDER into the
+    // caching the parsed type priorities. As part of this process, we put a PLACEHOLDER into the
     // map which is replaced when the type system is actually loaded
     Map<String, String> locationStrings = new HashMap<>();
     typePriorities.keySet().stream().forEach(loc -> locationStrings.put(loc, loc));

--- a/uimafit-core/src/test/java/org/apache/uima/fit/ComponentTestBase.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/ComponentTestBase.java
@@ -29,10 +29,6 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * 
- * 
- */
 public class ComponentTestBase {
 
   private static ThreadLocal<JCas> JCAS = new ThreadLocal<JCas>();

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/FsIndexFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/FsIndexFactoryTest.java
@@ -41,9 +41,11 @@ import org.apache.uima.fit.descriptor.FsIndex;
 import org.apache.uima.fit.descriptor.FsIndexCollection;
 import org.apache.uima.fit.descriptor.FsIndexKey;
 import org.apache.uima.fit.factory.spi.FsIndexCollectionProviderForTesting;
+import org.apache.uima.fit.internal.ResourceManagerFactory;
 import org.apache.uima.fit.type.Sentence;
 import org.apache.uima.fit.type.Token;
 import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.metadata.FsIndexDescription;
 import org.apache.uima.resource.metadata.FsIndexKeyDescription;
 import org.junit.jupiter.api.Test;
@@ -152,8 +154,10 @@ public class FsIndexFactoryTest extends ComponentTestBase {
 
   @Test
   public void testLoadingFromScannedLocations() throws Exception {
+    ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
+
     List<FsIndexDescription> indexes = new ArrayList<>();
-    loadFsIndexCollectionsFromScannedLocations(indexes);
+    loadFsIndexCollectionsFromScannedLocations(indexes, resMgr);
     org.apache.uima.resource.metadata.FsIndexCollection fsIndexCollection = FsIndexFactory
             .createFsIndexCollection(indexes);
 

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypePrioritiesFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypePrioritiesFactoryTest.java
@@ -31,9 +31,11 @@ import java.util.List;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.factory.spi.TypePrioritiesProviderForTesting;
+import org.apache.uima.fit.internal.ResourceManagerFactory;
 import org.apache.uima.fit.type.Sentence;
 import org.apache.uima.fit.type.Token;
 import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.metadata.TypePriorities;
 import org.apache.uima.resource.metadata.TypePriorityList;
 import org.apache.uima.util.CasCreationUtils;
@@ -88,8 +90,10 @@ public class TypePrioritiesFactoryTest {
 
   @Test
   public void testLoadingFromScannedLocations() throws Exception {
+    ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
+
     List<TypePriorities> allPrios = new ArrayList<>();
-    loadTypePrioritiesFromScannedLocations(allPrios);
+    loadTypePrioritiesFromScannedLocations(allPrios, resMgr);
     TypePriorities prios = CasCreationUtils.mergeTypePriorities(allPrios, null);
 
     assertThat(prios.getPriorityLists().length).isEqualTo(1);

--- a/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactoryTest.java
+++ b/uimafit-core/src/test/java/org/apache/uima/fit/factory/TypeSystemDescriptionFactoryTest.java
@@ -27,9 +27,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.uima.fit.factory.spi.TypeSystemDescriptionProviderForTesting;
+import org.apache.uima.fit.internal.ResourceManagerFactory;
 import org.apache.uima.fit.type.AnalyzedText;
 import org.apache.uima.fit.type.Sentence;
 import org.apache.uima.fit.type.Token;
+import org.apache.uima.resource.ResourceManager;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.Test;
@@ -54,8 +56,10 @@ public class TypeSystemDescriptionFactoryTest {
 
   @Test
   public void testLoadingFromScannedLocations() throws Exception {
+    ResourceManager resMgr = ResourceManagerFactory.newResourceManager();
+
     List<TypeSystemDescription> tsds = new ArrayList<>();
-    loadTypeSystemDescriptionsFromScannedLocations(tsds);
+    loadTypeSystemDescriptionsFromScannedLocations(tsds, resMgr);
     TypeSystemDescription tsd = CasCreationUtils.mergeTypeSystems(tsds);
 
     assertNotNull(tsd.getType(Token.class.getName()));


### PR DESCRIPTION
**What's in the PR**
- [x] Implement a per-location caching of pre-parsed and pre-resolved type system descriptions
- [x] Implement a per-location caching of pre-parsed and pre-resolved type priority descriptions
- [ ] Implement a per-location caching of pre-parsed and pre-resolved index descriptions

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
